### PR TITLE
add any-type-field, increase json type coverage

### DIFF
--- a/example/assets/mock-data/record.json
+++ b/example/assets/mock-data/record.json
@@ -1,5 +1,10 @@
 {
   "$schema": "http://localhost:5000/schemas/records/hep.json",
+  "_collections": [
+    "Literature"
+  ],
+  "_created": "2016-10-12T12:55:00.496965+00:00",
+  "_updated": "2016-10-12T12:55:00.496980+00:00",
   "abstracts": [
     {
       "source": "arXiv",
@@ -10,6 +15,12 @@
     {
       "curated_relation": true,
       "experiment": "CERN-LHC-ATLAS",
+      "facet_experiment": [
+        [
+          "CERN-LHC-ATLAS"
+        ]
+      ],
+      "recid": 1108541,
       "record": {
         "$ref": "http://localhost:5000/api/experiments/1108541"
       }
@@ -17,17 +28,34 @@
     {
       "curated_relation": true,
       "experiment": "CERN-LHC-CMS",
+      "facet_experiment": [
+        [
+          "CERN-LHC-CMS"
+        ]
+      ],
+      "recid": 1108642,
       "record": {
         "$ref": "http://localhost:5000/api/experiments/1108642"
       }
     },
     {
       "curated_relation": false,
-      "experiment": "FNAL-E-0830"
+      "experiment": "FNAL-E-0830",
+      "facet_experiment": [
+        [
+          "FNAL-E-0830"
+        ]
+      ]
     },
     {
       "curated_relation": true,
       "experiment": "CERN-LHC-LHCB",
+      "facet_experiment": [
+        [
+          "CERN-LHC-LHCb"
+        ]
+      ],
+      "recid": 1110643,
       "record": {
         "$ref": "http://localhost:5000/api/experiments/1110643"
       }
@@ -35,6 +63,12 @@
     {
       "curated_relation": true,
       "experiment": "FNAL-E-0823",
+      "facet_experiment": [
+        [
+          "FNAL-E-0823"
+        ]
+      ],
+      "recid": 1110315,
       "record": {
         "$ref": "http://localhost:5000/api/experiments/1110315"
       }
@@ -57,8 +91,37 @@
       ],
       "curated_relation": false,
       "full_name": "Cristinziani, Markus",
-      "inspire_bai": "M.Cristinziani.1",
-      "uuid": "5cabbef0-ead5-4433-b472-8f63713f92a8"
+      "ids": [
+        {
+          "type": "INSPIRE BAI",
+          "value": "M.Cristinziani.1"
+        }
+      ],
+      "name_suggest": {
+        "input": [
+          "Cristinziani",
+          "Cristinziani M",
+          "Cristinziani Markus",
+          "Cristinziani, M",
+          "Cristinziani, Markus",
+          "M Cristinziani",
+          "Markus Cristinziani"
+        ],
+        "output": "Cristinziani, Markus",
+        "payload": {
+          "bai": "M.Cristinziani.1"
+        }
+      },
+      "name_variations": [
+        "Cristinziani",
+        "Cristinziani M",
+        "Cristinziani Markus",
+        "Cristinziani, M",
+        "Cristinziani, Markus",
+        "M Cristinziani",
+        "Markus Cristinziani"
+      ],
+      "uuid": "a4324369-25d6-4f08-8f13-72970abeb00e"
     }
   ],
   "collaboration": [
@@ -125,6 +188,13 @@
       "value": "2069160"
     }
   ],
+  "facet_inspire_doc_type": [
+    "conference paper"
+  ],
+  "facet_inspire_subjects": [
+    "Experiment-HEP",
+    "Experiment-HEP"
+  ],
   "field_categories": [
     {
       "_scheme": "arXiv",
@@ -139,563 +209,7 @@
       "term": "Experiment-HEP"
     }
   ],
-  "license": [
-    {
-      "imposing": "arXiv",
-      "url": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/"
-    }
-  ],
-  "page_nr": [
-    "21"
-  ],
-  "preprint_date": "2015-11-13",
-  "public_notes": [
-    {
-      "source": "arXiv",
-      "value": "on behalf of the ATLAS, CDF, CMS, D0 and LHCb Collaborations. Conference proceedings for Lepton Photon, Ljubljana, 17-22 August 2015, 21 pages, 18 figures"
-    }
-  ],
-  "publication_info": [
-    {
-      "cnum": [
-        "C15-08-17"
-      ]
-    }
-  ],
-  "references": [
-    {
-      "authors": [
-        {
-          "full_name": "K. Melnikov"
-        }
-      ],
-      "misc": [
-        "Theoretical Results on Top Quark Physics, talk at this conference"
-      ],
-      "number": 1,
-      "urls": [
-        {
-          "value": "https://indico.cern.ch/event/325831/session/10/contribution/30"
-        }
-      ]
-    },
-    {
-      "authors": [
-        {
-          "full_name": "A. Meyer"
-        }
-      ],
-      "misc": [
-        "Determination of Top Quark Properties, talk at this conference"
-      ],
-      "number": 2,
-      "urls": [
-        {
-          "value": "https://indico.cern.ch/event/325831/session/10/contribution/32"
-        }
-      ]
-    },
-    {
-      "authors": [
-        {
-          "full_name": "T. Aaltonen"
-        }
-      ],
-      "collaboration": [
-        "D0 Collaborations"
-      ],
-      "misc": [
-        "(CDF Combination of measurements of the top-quark pair production cross section from the Tevatron Collider"
-      ],
-      "number": 3,
-      "publication_info": {
-        "artid": "072001",
-        "journal_title": "Phys.Rev.",
-        "journal_volume": "D89",
-        "year": 2014
-      }
-    },
-    {
-      "collaboration": [
-        "D0 Collaboration"
-      ],
-      "misc": [
-        "Measurement of the inclusive t\u00aft production cross section in p\u00afp collisions at \u221a s = 1.96 TeV, D0 Note 6453-CONF, wwwd0.fnal.gov/Run2Physics/WWW/results/prelim/TOP/T106"
-      ],
-      "number": 4
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurements of the top quark branching ratios into channels with leptons and quarks with the ATLAS detector"
-      ],
-      "number": 5,
-      "publication_info": {
-        "artid": "072005",
-        "journal_title": "Phys.Rev.",
-        "journal_volume": "D92",
-        "year": 2015
-      },
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1376287"
-      }
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Measurement of the top pair production cross section in 8 TeV proton-proton collisions using kinematic information in the lepton+jets final state with ATLAS"
-      ],
-      "number": 6,
-      "publication_info": {
-        "artid": "112013",
-        "journal_title": "Phys.Rev.",
-        "journal_volume": "D91",
-        "year": 2015
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaborations"
-      ],
-      "misc": [
-        "ATLAS Combination of ATLAS and CMS top quark pair cross section measurements in the e\u00b5 final state using proton-proton collisions at \u221a s = 8 TeV, ATLAS-CONF-054"
-      ],
-      "number": 7,
-      "publication_info": {
-        "reportnumber": "CMS-PAS-TOP-14-016",
-        "year": 2014
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1319552"
-        },
-        {
-          "value": "http://inspirehep.net/record/1319376"
-        }
-      ]
-    },
-    {
-      "collaboration": [
-        "CMS Collaborations"
-      ],
-      "misc": [
-        "ATLAS TOPLHCWG summary plots, twiki.cern.ch/twiki/bin/view/LHCPhysics/TopLHCWGSummaryPlots"
-      ],
-      "number": 8
-    },
-    {
-      "authors": [
-        {
-          "full_name": "R. Aaij"
-        }
-      ],
-      "curated_relation": false,
-      "misc": [
-        "LHCb Collaboration First observation of top quark production in the forward region"
-      ],
-      "number": 9,
-      "publication_info": {
-        "artid": "112001",
-        "journal_title": "Phys.Rev.Lett.",
-        "journal_volume": "115",
-        "year": 2015
-      },
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1374216"
-      }
-    },
-    {
-      "authors": [
-        {
-          "full_name": "B. Heinemann"
-        }
-      ],
-      "misc": [
-        "ATLAS Results from Run2, talk at this conference"
-      ],
-      "number": 10,
-      "urls": [
-        {
-          "value": "https://indico.cern.ch/event/325831/session/0/contribution/8"
-        }
-      ]
-    },
-    {
-      "authors": [
-        {
-          "full_name": "L. Malgeri"
-        }
-      ],
-      "misc": [
-        "CMS Results from Run2, talk at this conference"
-      ],
-      "number": 11,
-      "urls": [
-        {
-          "value": "https://indico.cern.ch/event/325831/session/0/contribution/9"
-        }
-      ]
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Measurement of the t\u00aft production cross-section in pp collisions at \u221a s = 13 TeV using e\u00b5 events with b-tagged jets, ATLAS-CONF-033"
-      ],
-      "number": 12,
-      "publication_info": {
-        "year": 2015
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1385192"
-        }
-      ]
-    },
-    {
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurement of the top quark pair production cross section in proton-proton collisions at \u221a s = 13 TeV"
-      ],
-      "number": 13,
-      "publication_info": {
-        "reportnumber": "CMS-PAS-TOP-15-003"
-      },
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1388254"
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1388254"
-        }
-      ]
-    },
-    {
-      "arxiv_eprints": [
-        "arXiv:1505.04480"
-      ],
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurement of the differential cross section for top quark pair production in pp collisions at \u221a s = 8 TeV, submitted to Eur. Phys. J. C"
-      ],
-      "number": 14,
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1370682"
-      }
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Differential top-antitop cross-section measurements as a function of observables constructed from final-state particles using pp collisions at \u221a s = 7 TeV in the ATLAS detector"
-      ],
-      "number": 15,
-      "publication_info": {
-        "artid": "100",
-        "journal_title": "JHEP",
-        "journal_volume": "1506",
-        "page_start": "100",
-        "year": 2015
-      }
-    },
-    {
-      "arxiv_eprints": [
-        "arXiv:1510.03818"
-      ],
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurement of the differential cross-section of highly boosted top quarks as a function of their transverse momentum in \u221a s = 8 TeV proton-proton collisions using the ATLAS detector, submitted to PRD"
-      ],
-      "number": 16,
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1397637"
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurement of the differential t\u00aft production cross section for high-pT top quarks in e/\u00b5+jets final states at \u221a s = 8 TeV"
-      ],
-      "number": 17,
-      "publication_info": {
-        "reportnumber": "CMS-PAS-TOP-14-012"
-      },
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1388555"
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1388555"
-        }
-      ]
-    },
-    {
-      "authors": [
-        {
-          "full_name": "T. Aaltonen"
-        }
-      ],
-      "collaboration": [
-        "D0 Collaborations"
-      ],
-      "misc": [
-        "(CDF Tevatron combination of single-top-quark cross sections and determination of the magnitude of the Cabibbo-Kobayashi-Maskawa matrix element Vtb"
-      ],
-      "number": 18,
-      "publication_info": {
-        "artid": "152003",
-        "journal_title": "Phys.Rev.Lett.",
-        "journal_volume": "115",
-        "year": 2015
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "misc": [
-        "Measurements of the differential cross section of single top-quark production in the t channel in proton-proton collisions at \u221a s = 8 TeV"
-      ],
-      "number": 19,
-      "publication_info": {
-        "reportnumber": "CMS-PAS-TOP-14-004"
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1323200"
-        }
-      ]
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Search for s-channel single top-quark production in proton-proton collisions at \u221a s = 8 TeV with the ATLAS detector"
-      ],
-      "number": 20,
-      "publication_info": {
-        "artid": "118",
-        "journal_title": "Phys.Lett.",
-        "journal_volume": "B740",
-        "page_start": "118",
-        "year": 2015
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaborations"
-      ],
-      "misc": [
-        "ATLAS Combination of cross-section measurements for associated production of a single top-quark and a W boson at\u221a s = 8 TeV with the ATLAS and CMS experiments, ATLAS-CONF-052 and"
-      ],
-      "number": 21,
-      "publication_info": {
-        "reportnumber": "CMS-PAS-TOP-14-009",
-        "year": 2014
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1319379"
-        },
-        {
-          "value": "http://inspirehep.net/record/1319686"
-        }
-      ]
-    },
-    {
-      "authors": [
-        {
-          "full_name": "S. Farrington"
-        }
-      ],
-      "misc": [
-        "Results on the Standard Model Higgs boson, talk at this conference"
-      ],
-      "number": 22,
-      "urls": [
-        {
-          "value": "https://indico.cern.ch/event/325831/contribution/11"
-        }
-      ]
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Observation of top-quark pair production in association with a photon and measurement of the t\u00aft\u03b3 production cross section in pp collisions at \u221a s = 7 TeVusing the ATLAS detector"
-      ],
-      "number": 23,
-      "publication_info": {
-        "artid": "072007",
-        "journal_title": "Phys.Rev.",
-        "journal_volume": "D91",
-        "year": 2015
-      }
-    },
-    {
-      "arxiv_eprints": [
-        "arXiv:1509.05276"
-      ],
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurement of the t\u00aftW and t\u00aftZ production cross sections in pp collisions at \u221a s = 8 TeV with the ATLAS detector, accepted by JHEP"
-      ],
-      "number": 24,
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1393760"
-      }
-    },
-    {
-      "arxiv_eprints": [
-        "arXiv:1510.01131"
-      ],
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Observation of top quark pairs produced in association with a vector boson in pp collisions at \u221a s = 8 TeV, submitted to JHEP"
-      ],
-      "number": 25,
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1396140"
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "misc": [
-        "Measurement of the cross section ratio \u03c3t\u00aftb\u00afb/\u03c3t\u00aftjj in pp collisions at \u221a s = 8 TeV"
-      ],
-      "number": 26,
-      "publication_info": {
-        "artid": "132",
-        "journal_title": "Phys.Lett.",
-        "journal_volume": "B746",
-        "page_start": "132",
-        "year": 2015
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurement of the t\u00aftb\u00afb cross section and the ratio \u03c3(t\u00aftb\u00afb)/\u03c3(t\u00aftjj) in the lepton+jets final state at 8 TeV with the CMS detector"
-      ],
-      "number": 27,
-      "publication_info": {
-        "reportnumber": "CMS-PAS-TOP-13-016"
-      },
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1385669"
-      },
-      "urls": [
-        {
-          "value": "http://inspirehep.net/record/1385669"
-        }
-      ]
-    },
-    {
-      "arxiv_eprints": [
-        "arXiv:1508.06868"
-      ],
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "curated_relation": false,
-      "misc": [
-        "Measurements of fiducial cross-sections for t\u00aft production with one or two additional b-jets in pp collisions at \u221a s = 8 TeV using the ATLAS detector, submitted to Eur. Phys. J. C"
-      ],
-      "number": 28,
-      "record": {
-        "$ref": "http://localhost:5000/api/literature/1390114"
-      }
-    },
-    {
-      "collaboration": [
-        "CMS Collaboration"
-      ],
-      "misc": [
-        "Search for standard model production of four top quarks in the lepton + jets channel in pp collisions at \u221a s = 8 TeV"
-      ],
-      "number": 29,
-      "publication_info": {
-        "artid": "154",
-        "journal_title": "JHEP",
-        "journal_volume": "1411",
-        "page_start": "154",
-        "year": 2014
-      }
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Analysis of events with b-jets and a pair of leptons of the same charge in pp collisions at \u221a s = 8 TeV with the ATLAS detector"
-      ],
-      "number": 30,
-      "publication_info": {
-        "artid": "150",
-        "journal_title": "JHEP",
-        "journal_volume": "1510",
-        "page_start": "150",
-        "year": 2015
-      }
-    },
-    {
-      "collaboration": [
-        "ATLAS Collaboration"
-      ],
-      "misc": [
-        "Search for production of vector-like quark pairs and of four top quarks in the lepton-plus-jets final state in pp collisions at \u221a s = 8 TeV with the ATLAS detector"
-      ],
-      "number": 31,
-      "publication_info": {
-        "artid": "105",
-        "journal_title": "JHEP",
-        "journal_volume": "1508",
-        "page_start": "105",
-        "year": 2015
-      }
-    }
-  ],
-  "report_numbers": [
-    {
-      "value": "ATL-PHYS-PROC-2015-144"
-    }
-  ],
-  "self": {
-    "$ref": "http://localhost:5000/api/literature/1404685"
-  },
-  "thesaurus_terms": [
+  "keywords": [
     {
       "classification_scheme": "INSPIRE",
       "keyword": "talk: Ljubljana 2015/08/17"
@@ -773,6 +287,583 @@
       "keyword": "experimental results"
     }
   ],
+  "license": [
+    {
+      "imposing": "arXiv",
+      "url": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/"
+    }
+  ],
+  "page_nr": [
+    "21"
+  ],
+  "preprint_date": "2015-11-13",
+  "public_notes": [
+    {
+      "source": "arXiv",
+      "value": "on behalf of the ATLAS, CDF, CMS, D0 and LHCb Collaborations. Conference proceedings for Lepton Photon, Ljubljana, 17-22 August 2015, 21 pages, 18 figures"
+    }
+  ],
+  "publication_info": [
+    {
+      "cnum": "C15-08-17"
+    }
+  ],
+  "references": [
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "K. Melnikov"
+          }
+        ],
+        "misc": [
+          "Theoretical Results on Top Quark Physics, talk at this conference"
+        ],
+        "number": 1,
+        "urls": [
+          {
+            "value": "https://indico.cern.ch/event/325831/session/10/contribution/30"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "A. Meyer"
+          }
+        ],
+        "misc": [
+          "Determination of Top Quark Properties, talk at this conference"
+        ],
+        "number": 2,
+        "urls": [
+          {
+            "value": "https://indico.cern.ch/event/325831/session/10/contribution/32"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "T. Aaltonen"
+          }
+        ],
+        "collaboration": [
+          "D0 Collaborations"
+        ],
+        "misc": [
+          "(CDF Combination of measurements of the top-quark pair production cross section from the Tevatron Collider"
+        ],
+        "number": 3,
+        "publication_info": {
+          "year": 2014
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "D0 Collaboration"
+        ],
+        "misc": [
+          "Measurement of the inclusive t\u00aft production cross section in p\u00afp collisions at \u221a s = 1.96 TeV, D0 Note 6453-CONF, wwwd0.fnal.gov/Run2Physics/WWW/results/prelim/TOP/T106"
+        ],
+        "number": 4
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1376287,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1376287"
+      },
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Measurements of the top quark branching ratios into channels with leptons and quarks with the ATLAS detector"
+        ],
+        "number": 5,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the top pair production cross section in 8 TeV proton-proton collisions using kinematic information in the lepton+jets final state with ATLAS"
+        ],
+        "number": 6,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "CMS Collaborations"
+        ],
+        "misc": [
+          "ATLAS Combination of ATLAS and CMS top quark pair cross section measurements in the e\u00b5 final state using proton-proton collisions at \u221a s = 8 TeV, ATLAS-CONF-054"
+        ],
+        "number": 7,
+        "publication_info": {
+          "year": 2014
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1319376"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "CMS Collaborations"
+        ],
+        "misc": [
+          "ATLAS TOPLHCWG summary plots, twiki.cern.ch/twiki/bin/view/LHCPhysics/TopLHCWGSummaryPlots"
+        ],
+        "number": 8
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1374216,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1374216"
+      },
+      "reference": {
+        "authors": [
+          {
+            "full_name": "R. Aaij"
+          }
+        ],
+        "misc": [
+          "LHCb Collaboration First observation of top quark production in the forward region"
+        ],
+        "number": 9,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "B. Heinemann"
+          }
+        ],
+        "misc": [
+          "ATLAS Results from Run2, talk at this conference"
+        ],
+        "number": 10,
+        "urls": [
+          {
+            "value": "https://indico.cern.ch/event/325831/session/0/contribution/8"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "L. Malgeri"
+          }
+        ],
+        "misc": [
+          "CMS Results from Run2, talk at this conference"
+        ],
+        "number": 11,
+        "urls": [
+          {
+            "value": "https://indico.cern.ch/event/325831/session/0/contribution/9"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the t\u00aft production cross-section in pp collisions at \u221a s = 13 TeV using e\u00b5 events with b-tagged jets, ATLAS-CONF-033"
+        ],
+        "number": 12,
+        "publication_info": {
+          "year": 2015
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1385192"
+          }
+        ]
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1388254,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1388254"
+      },
+      "reference": {
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the top quark pair production cross section in proton-proton collisions at \u221a s = 13 TeV"
+        ],
+        "number": 13,
+        "publication_info": {
+          "reportnumber": "CMS-PAS-TOP-15-003"
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1388254"
+          }
+        ]
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1370682,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1370682"
+      },
+      "reference": {
+        "arxiv_eprints": [
+          "arXiv:1505.04480"
+        ],
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the differential cross section for top quark pair production in pp collisions at \u221a s = 8 TeV, submitted to Eur. Phys. J. C"
+        ],
+        "number": 14
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Differential top-antitop cross-section measurements as a function of observables constructed from final-state particles using pp collisions at \u221a s = 7 TeV in the ATLAS detector"
+        ],
+        "number": 15,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1397637,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1397637"
+      },
+      "reference": {
+        "arxiv_eprints": [
+          "arXiv:1510.03818"
+        ],
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the differential cross-section of highly boosted top quarks as a function of their transverse momentum in \u221a s = 8 TeV proton-proton collisions using the ATLAS detector, submitted to PRD"
+        ],
+        "number": 16
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1388555,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1388555"
+      },
+      "reference": {
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the differential t\u00aft production cross section for high-pT top quarks in e/\u00b5+jets final states at \u221a s = 8 TeV"
+        ],
+        "number": 17,
+        "publication_info": {
+          "reportnumber": "CMS-PAS-TOP-14-012"
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1388555"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "T. Aaltonen"
+          }
+        ],
+        "collaboration": [
+          "D0 Collaborations"
+        ],
+        "misc": [
+          "(CDF Tevatron combination of single-top-quark cross sections and determination of the magnitude of the Cabibbo-Kobayashi-Maskawa matrix element Vtb"
+        ],
+        "number": 18,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Measurements of the differential cross section of single top-quark production in the t channel in proton-proton collisions at \u221a s = 8 TeV"
+        ],
+        "number": 19,
+        "publication_info": {
+          "reportnumber": "CMS-PAS-TOP-14-004"
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1323200"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Search for s-channel single top-quark production in proton-proton collisions at \u221a s = 8 TeV with the ATLAS detector"
+        ],
+        "number": 20,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "CMS Collaborations"
+        ],
+        "misc": [
+          "ATLAS Combination of cross-section measurements for associated production of a single top-quark and a W boson at\u221a s = 8 TeV with the ATLAS and CMS experiments, ATLAS-CONF-052 and"
+        ],
+        "number": 21,
+        "publication_info": {
+          "year": 2014
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1319686"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "authors": [
+          {
+            "full_name": "S. Farrington"
+          }
+        ],
+        "misc": [
+          "Results on the Standard Model Higgs boson, talk at this conference"
+        ],
+        "number": 22,
+        "urls": [
+          {
+            "value": "https://indico.cern.ch/event/325831/contribution/11"
+          }
+        ]
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Observation of top-quark pair production in association with a photon and measurement of the t\u00aft\u03b3 production cross section in pp collisions at \u221a s = 7 TeVusing the ATLAS detector"
+        ],
+        "number": 23,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1393760,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1393760"
+      },
+      "reference": {
+        "arxiv_eprints": [
+          "arXiv:1509.05276"
+        ],
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the t\u00aftW and t\u00aftZ production cross sections in pp collisions at \u221a s = 8 TeV with the ATLAS detector, accepted by JHEP"
+        ],
+        "number": 24
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1396140,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1396140"
+      },
+      "reference": {
+        "arxiv_eprints": [
+          "arXiv:1510.01131"
+        ],
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Observation of top quark pairs produced in association with a vector boson in pp collisions at \u221a s = 8 TeV, submitted to JHEP"
+        ],
+        "number": 25
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the cross section ratio \u03c3t\u00aftb\u00afb/\u03c3t\u00aftjj in pp collisions at \u221a s = 8 TeV"
+        ],
+        "number": 26,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1385669,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1385669"
+      },
+      "reference": {
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Measurement of the t\u00aftb\u00afb cross section and the ratio \u03c3(t\u00aftb\u00afb)/\u03c3(t\u00aftjj) in the lepton+jets final state at 8 TeV with the CMS detector"
+        ],
+        "number": 27,
+        "publication_info": {
+          "reportnumber": "CMS-PAS-TOP-13-016"
+        },
+        "urls": [
+          {
+            "value": "http://inspirehep.net/record/1385669"
+          }
+        ]
+      }
+    },
+    {
+      "curated_relation": false,
+      "recid": 1390114,
+      "record": {
+        "$ref": "http://localhost:5000/api/literature/1390114"
+      },
+      "reference": {
+        "arxiv_eprints": [
+          "arXiv:1508.06868"
+        ],
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Measurements of fiducial cross-sections for t\u00aft production with one or two additional b-jets in pp collisions at \u221a s = 8 TeV using the ATLAS detector, submitted to Eur. Phys. J. C"
+        ],
+        "number": 28
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "CMS Collaboration"
+        ],
+        "misc": [
+          "Search for standard model production of four top quarks in the lepton + jets channel in pp collisions at \u221a s = 8 TeV"
+        ],
+        "number": 29,
+        "publication_info": {
+          "year": 2014
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Analysis of events with b-jets and a pair of leptons of the same charge in pp collisions at \u221a s = 8 TeV with the ATLAS detector"
+        ],
+        "number": 30,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    },
+    {
+      "reference": {
+        "collaboration": [
+          "ATLAS Collaboration"
+        ],
+        "misc": [
+          "Search for production of vector-like quark pairs and of four top quarks in the lepton-plus-jets final state in pp collisions at \u221a s = 8 TeV with the ATLAS detector"
+        ],
+        "number": 31,
+        "publication_info": {
+          "year": 2015
+        }
+      }
+    }
+  ],
+  "report_numbers": [
+    {
+      "value": "ATL-PHYS-PROC-2015-144"
+    }
+  ],
+  "self": {
+    "$ref": "http://localhost:5000/api/literature/1404685"
+  },
+  "self_recid": 1404685,
   "titles": [
     {
       "source": "arXiv",

--- a/example/assets/mock-data/schema.json
+++ b/example/assets/mock-data/schema.json
@@ -1,1255 +1,1362 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "description": "An article or thesis or book or...",
+  "$schema": "http://json-schema.org/schema#", 
+  "description": "An article or thesis or book or...", 
   "properties": {
     "abstracts": {
-      "x_editor_priority": 100,
       "items": {
         "properties": {
           "source": {
             "type": "string"
-          },
+          }, 
           "value": {
-            "type": "string",
-            "x_editor_priority": 50
+            "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "accelerator_experiments": {
       "items": {
         "properties": {
           "accelerator": {
             "type": "string"
-          },
+          }, 
           "curated_relation": {
-            "default": false,
-            "description": "Was the experiment actually proofchecked by a cataloguer?",
+            "default": false, 
+            "description": "Was the experiment actually proofchecked by a cataloguer?", 
             "type": "boolean"
-          },
+          }, 
           "experiment": {
             "type": "string"
-          },
-          "facets_experiment": {
-            "description": "Experiment name to be used on facets.",
-            "type": "string"
-          },
+          }, 
           "institution": {
             "type": "string"
-          },
+          }, 
           "record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
-            "type": "object",
-            "description": "URI for the corresponding experiment record."
+            ], 
+            "type": "object"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "acquisition_source": {
+      "$schema": "http://json-schema.org/schema#", 
       "properties": {
         "date": {
-          "description": "Date of acquisition",
           "type": "string"
-        },
+        }, 
         "email": {
-          "description": "Email of acquisition contact",
           "type": "string"
-        },
+        }, 
         "method": {
-          "description": "Method of acquisition",
           "type": "string"
-        },
+        }, 
         "source": {
-          "description": "Source of acquisition",
           "type": "string"
-        },
+        }, 
         "submission_number": {
-          "description": "Special submission ID",
           "type": "string"
         }
-      },
+      }, 
       "type": "object"
-    },
+    }, 
     "arxiv_eprints": {
       "items": {
         "properties": {
           "categories": {
             "items": {
               "type": "string"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "pattern": "\\d{4}.\\d{4,5}|\\w+-\\w+/\\d+|\\w+/\\d+",
+            "pattern": "\\d{4}.\\d{4,5}|\\w+-\\w+/\\d+|\\w+/\\d+", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "authors": {
-      "description": "List with all the authors",
+      "description": "List with all the authors", 
       "items": {
         "properties": {
           "affiliations": {
             "items": {
               "properties": {
                 "curated_relation": {
-                  "description": "Did a cataloguer proof-checked the recid?",
-                  "title": "The affiliation is curated?",
+                  "description": "Did a cataloguer proof-checked the recid?", 
+                  "title": "The affiliation is curated?", 
                   "type": "boolean"
-                },
+                }, 
                 "record": {
+                  "$schema": "http://json-schema.org/schema#", 
                   "properties": {
                     "$ref": {
-                      "description": "URL to the referenced resource",
-                      "format": "url",
+                      "description": "URL to the referenced resource", 
+                      "format": "url", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "required": [
                     "$ref"
-                  ],
-                  "type": "object",
-                  "description": "URI for the Institution collection record",
-                  "title": "URI for the Institution collection record"
-                },
+                  ], 
+                  "type": "object"
+                }, 
                 "value": {
-                  "x_editor_priority": 50,
-                  "description": "The affiliation as it appears on the paper",
-                  "title": "Name of institution",
+                  "description": "The affiliation as it appears on the paper", 
+                  "title": "Name of institution", 
                   "type": "string"
                 }
-              },
-              "title": "Affiliation",
+              }, 
+              "title": "Affiliation", 
               "type": "object"
-            },
-            "title": "Affiliations",
-            "type": "array",
+            }, 
+            "title": "Affiliations", 
+            "type": "array", 
             "uniqueItems": true
-          },
-          "alternative_name": {
-            "description": "FIXME: needed for import only",
-            "title": "Alternative author name",
-            "type": "string"
-          },
+          }, 
+          "alternative_names": {
+            "items": {
+              "type": "string"
+            }, 
+            "type": "array"
+          }, 
           "contributor_roles": {
             "items": {
               "properties": {
-                "source": {
+                "schema": {
                   "enum": [
                     "CRediT"
-                  ],
+                  ], 
                   "type": "string"
-                },
+                }, 
                 "value": {
-                  "x_editor_priority": 50,
                   "enum": [
-                    "Conceptualization",
-                    "Data curation",
-                    "Formal analysis",
-                    "Funding acquisition",
-                    "Investigation",
-                    "Methodology",
-                    "Project administration",
-                    "Resources",
-                    "Software",
-                    "Supervision",
-                    "Validation",
-                    "Visualization",
-                    "Writing \u2013 original draft",
-                    "Writing \u2013 review & editing"
-                  ],
+                    "Conceptualization", 
+                    "Data curation", 
+                    "Formal analysis", 
+                    "Funding acquisition", 
+                    "Investigation", 
+                    "Methodology", 
+                    "Project administration", 
+                    "Resources", 
+                    "Software", 
+                    "Supervision", 
+                    "Validation", 
+                    "Visualization", 
+                    "Writing - original draft", 
+                    "Writing - review & editing"
+                  ], 
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
-            },
-            "type": "array",
+            }, 
+            "type": "array", 
             "uniqueItems": true
-          },
+          }, 
           "curated_relation": {
-            "default": false,
-            "description": "Was this signature actually claimed or proof-checked by cataloguer?",
-            "title": "The relation is curated?",
+            "default": false, 
+            "description": "Was this signature actually claimed or proof-checked by cataloguer?", 
+            "title": "The relation is curated?", 
             "type": "boolean"
-          },
-          "email": {
-            "format": "email",
-            "title": "Email",
-            "type": "string"
-          },
-          "full_name": {
-            "description": "author name as it appears in the paper",
-            "title": "Author name",
-            "type": "string"
-          },
-          "inspire_bai": {
-            "description": "INSPIRE BAI when available",
-            "pattern": "(\\w+\\.)+\\d+",
-            "title": "INSPIRE BibAuthorID",
-            "type": "string",
-            "x_editor_hidden": true
-          },
-          "inspire_id": {
-            "description": "Legacy INSPIRE ID when available",
-            "pattern": "INSPIRE-\\d+",
-            "title": "INSPIRE ID",
-            "type": "string"
-          },
-          "name_variations": {
-            "description": "All possible variations of the authors full name.",
-            "title": "Author name variations",
-            "type": "string"
-          },
-          "orcid": {
-            "description": "ORCID Id when available",
-            "format": "orcid",
-            "pattern": "\\d{4}-\\d{4}-\\d{4}-\\d{4}",
-            "title": "ORCID ID",
-            "type": "string"
-          },
-          "other_ids": {
-            "description": "Just in case...",
+          }, 
+          "emails": {
             "items": {
-              "properties": {
-                "source": {
-                  "title": "Source of ID",
-                  "type": "string"
-                },
-                "value": {
-                  "x_editor_priority": 50,
-                  "title": "ID",
-                  "type": "string"
-                }
-              },
-              "title": "ID",
-              "type": "object"
-            },
-            "title": "Other IDs",
+              "format": "email", 
+              "type": "string"
+            }, 
             "type": "array"
-          },
+          }, 
+          "full_name": {
+            "description": "author name as it appears in the paper", 
+            "title": "Author name", 
+            "type": "string"
+          }, 
+          "ids": {
+            "items": {
+              "$schema": "http://json-schema.org/schema#", 
+              "anyOf": [
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "INSPIRE ID"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "INSPIRE-\\d{8}", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "INSPIRE BAI"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "(\\w+\\.)+\\d+", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "ORCID"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9Xx]", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "JACOW"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "JACoW-\\d{8}", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "KAKEN"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "KAKEN-\\d{8}", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "ARXIV"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "\\w+_(\\w_)?\\d+", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "CERN"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "CERN-\\d+", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "DESY"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "DESY-\\d+", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "GOOGLESCHOLAR"
+                      ]
+                    }, 
+                    "value": {
+                      "pattern": "(\\w|-){12}", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "VIAF"
+                      ]
+                    }, 
+                    "value": {
+                      "pattern": "\\d{7,9}", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "RESEARCHERID"
+                      ]
+                    }, 
+                    "value": {
+                      "pattern": "[A-z]-\\d{4}-\\d{4}", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "SCOPUS"
+                      ]
+                    }, 
+                    "value": {
+                      "pattern": "\\d{10,11}", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "WIKIPEDIA"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "\\w+", 
+                      "type": "string"
+                    }
+                  }
+                }, 
+                {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "SLAC"
+                      ], 
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "pattern": "SLAC-\\d+", 
+                      "type": "string"
+                    }
+                  }
+                }
+              ], 
+              "required": [
+                "type", 
+                "value"
+              ]
+            }, 
+            "type": "array", 
+            "uniqueItems": true
+          }, 
           "record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
-            "type": "object",
-            "description": "URI for the person record",
-            "title": "URI for the person record"
-          },
-          "role": {
-            "description": "Role of the author within the paper. So far only Editor was captured.",
-            "title": "Role of the person",
-            "type": "string"
-          },
-          "signature_block": {
-            "description": "Phonetic notation of the author's name.",
-            "title": "Phonetic name",
-            "type": "string"
-          },
+            ], 
+            "type": "object"
+          }, 
           "uuid": {
-            "description": "Universally unique identifier of the author.",
-            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
-            "title": "UUID",
-            "type": "string",
-            "x_editor_hidden": true
+            "description": "Universally unique identifier of the author.", 
+            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", 
+            "title": "UUID", 
+            "type": "string"
           }
-        },
-        "title": "Author",
+        }, 
+        "title": "Author", 
         "type": "object"
-      },
-      "title": "Authors",
-      "type": "array",
+      }, 
+      "title": "Authors", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "book_series": {
       "items": {
         "properties": {
           "title": {
-            "description": "Title of the book series",
+            "description": "Title of the book series", 
             "type": "string"
-          },
+          }, 
           "volume": {
-            "description": "Specific volume number",
+            "description": "Specific volume number", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "type": "array"
-    },
+    }, 
     "citeable": {
-      "description": "Whether this document can be cited. FIXME: can this be derived from other properties?",
-      "title": "Citeable?",
+      "description": "Whether this document can be cited. FIXME: can this be derived from other properties?", 
+      "title": "Citeable?", 
       "type": "boolean"
-    },
+    }, 
     "classification_number": {
       "items": {
         "properties": {
           "source": {
-            "title": "Source",
+            "title": "Source", 
             "type": "string"
-          },
+          }, 
           "standard": {
-            "title": "Standard",
+            "title": "Standard", 
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "description": "PACS or PDG codes. FIXME: What about better separating these into a PACS field and a PDG field?",
-            "title": "Number",
+            "description": "PACS or PDG codes. FIXME: What about better separating these into a PACS field and a PDG field?", 
+            "title": "Number", 
             "type": "string"
           }
-        },
-        "title": "Classification number",
+        }, 
+        "title": "Classification number", 
         "type": "object"
-      },
-      "title": "Classification numbers",
-      "type": "array",
+      }, 
+      "title": "Classification numbers", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "collaboration": {
       "items": {
         "properties": {
           "record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
+            ], 
             "type": "object"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "collections": {
       "items": {
         "properties": {
           "primary": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "minItems": 1,
-      "title": "Collection",
-      "type": "array",
+      }, 
+      "minItems": 1, 
+      "title": "Collection", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "copyright": {
       "items": {
         "properties": {
           "holder": {
-            "description": "Copyright holder.",
+            "description": "Copyright holder.", 
             "type": "string"
-          },
+          }, 
           "material": {
             "type": "string"
-          },
+          }, 
           "statement": {
-            "description": "FIXME: What's that? there are all sorts of usages on production!",
+            "description": "FIXME: What's that? there are all sorts of usages on production!", 
             "type": "string"
-          },
+          }, 
           "url": {
-            "format": "url",
+            "format": "url", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
+      }, 
       "type": "array"
-    },
+    }, 
     "core": {
-      "description": "Whether this document is CORE and hence need special curation. NOTE: set this explicitly to false, in order to have real noncore.",
+      "description": "Whether this document is CORE and hence need special curation. NOTE: set this explicitly to false, in order to have real noncore.", 
       "type": "boolean"
-    },
+    }, 
     "corporate_author": {
       "items": {
-        "title": "Corporate author",
+        "title": "Corporate author", 
         "type": "string"
-      },
-      "title": "Corporate authors",
-      "type": "array",
+      }, 
+      "title": "Corporate authors", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
+    "deleted": {
+      "type": "boolean"
+    }, 
     "deleted_records": {
-      "description": "List of deleted records referring to this record",
+      "description": "List of deleted records referring to this record", 
       "items": {
+        "$schema": "http://json-schema.org/schema#", 
         "properties": {
           "$ref": {
-            "description": "URL to the referenced resource",
-            "format": "url",
+            "description": "URL to the referenced resource", 
+            "format": "url", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "$ref"
-        ],
+        ], 
         "type": "object"
-      },
-      "title": "Deleted Records",
+      }, 
+      "title": "Deleted Records", 
       "type": "array"
-    },
+    }, 
     "document_type": {
       "items": {
         "enum": [
-          "Published",
-          "arXiv",
-          "ActivityReport",
-          "ConferencePaper",
-          "Thesis",
-          "Review",
-          "Lectures",
-          "Note",
-          "Proceedings",
-          "Introductory",
-          "Book",
-          "BookChapter",
+          "Published", 
+          "arXiv", 
+          "ActivityReport", 
+          "ConferencePaper", 
+          "Thesis", 
+          "Review", 
+          "Lectures", 
+          "Note", 
+          "Proceedings", 
+          "Introductory", 
+          "Book", 
+          "BookChapter", 
           "Report"
-        ],
+        ], 
         "type": "string"
-      },
-      "minItems": 1,
-      "title": "Document type",
-      "type": "array",
+      }, 
+      "minItems": 1, 
+      "title": "Document type", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "dois": {
       "items": {
         "properties": {
           "source": {
-            "description": "Issuing of DOI.",
-            "title": "DOI registrant",
-            "type": "string",
-            "x_editor_always_show": true
-          },
+            "description": "Issuing of DOI.", 
+            "title": "DOI registrant", 
+            "type": "string"
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "pattern": "10\\.\\d+(\\.\\d+)?/.+",
-            "title": "DOI",
-            "type": "string",
-            "x_editor_always_show": true
+            "pattern": "10\\.\\d+(\\.\\d+)?/.+", 
+            "title": "DOI", 
+            "type": "string"
           }
-        },
-        "title": "DOI",
+        }, 
+        "title": "DOI", 
         "type": "object"
-      },
-      "title": "DOIs",
-      "type": "array",
+      }, 
+      "title": "DOIs", 
+      "type": "array", 
       "uniqueItems": true
-    },
-    "earliest_date": {
-      "description": "The earliest date of this record among all types of dates",
-      "format": "date",
-      "type": "string"
-    },
+    }, 
     "edition": {
       "items": {
         "properties": {
           "edition": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
+    "energy_ranges": {
+      "description": "Ranges of energies the record refers to", 
+      "items": {
+        "minimum": 0, 
+        "type": "integer"
+      }, 
+      "type": "array"
+    }, 
     "external_system_numbers": {
       "items": {
         "properties": {
           "institute": {
-            "title": "Institute",
-            "type": "string",
-            "x_editor_disabled": true
-          },
+            "title": "Institute", 
+            "type": "string"
+          }, 
           "obsolete": {
-            "title": "Obsolete?",
+            "title": "Obsolete?", 
             "type": "boolean"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "title": "Number",
+            "title": "Number", 
             "type": "string"
           }
-        },
-        "title": "External system number",
+        }, 
+        "title": "External system number", 
         "type": "object"
-      },
-      "title": "External system numbers",
-      "type": "array",
+      }, 
+      "title": "External system numbers", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "field_categories": {
       "items": {
+        "$schema": "http://json-schema.org/schema#", 
         "properties": {
           "scheme": {
-            "title": "INSPIRE",
+            "title": "INSPIRE", 
             "type": "string"
-          },
+          }, 
           "source": {
             "enum": [
-              "INSPIRE",
-              "submitter",
-              "curator",
-              "publisher",
+              "INSPIRE", 
+              "submitter", 
+              "conference", 
+              "curator", 
+              "publisher", 
               "magpie"
-            ],
-            "type": "string",
-            "x_editor_disabled": true
-          },
+            ], 
+            "type": "string"
+          }, 
           "term": {
-            "x_editor_enum_shortcut_map": {
-              "acc": "Accelerators",
-              "ast": "Astrophysics",
-              "eh": "Experiment-HEP",
-              "l": "Lattice"
-            },
             "enum": [
-              "Accelerators",
-              "Astrophysics",
-              "Computing",
-              "Data Analysis and Statistics",
-              "Experiment-HEP",
-              "Experiment-Nucl",
-              "General Physics",
-              "Gravitation and Cosmology",
-              "Instrumentation",
-              "Lattice",
-              "Math and Math Physics",
-              "Other",
-              "Phenomenology-HEP",
-              "Theory-HEP",
+              "Accelerators", 
+              "Astrophysics", 
+              "Computing", 
+              "Data Analysis and Statistics", 
+              "Experiment-HEP", 
+              "Experiment-Nucl", 
+              "General Physics", 
+              "Gravitation and Cosmology", 
+              "Instrumentation", 
+              "Lattice", 
+              "Math and Math Physics", 
+              "Other", 
+              "Phenomenology-HEP", 
+              "Theory-HEP", 
               "Theory-Nucl"
-            ],
-            "title": "INSPIRE term",
+            ], 
+            "title": "INSPIRE term", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
-    "free_keywords": {
-      "items": {
-        "properties": {
-          "source": {
-            "type": "string"
-          },
-          "value": {
-            "x_editor_priority": 50,
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
+    }, 
     "funding_info": {
-      "description": "Information related to funding. FIXME: Do we care about this? So far only 349 records were tagged and all for a single EU project.",
+      "description": "Information related to funding. FIXME: Do we care about this? So far only 349 records were tagged and all for a single EU project.", 
       "items": {
         "properties": {
           "agency": {
-            "title": "Agency",
+            "title": "Agency", 
             "type": "string"
-          },
+          }, 
           "grant_number": {
-            "title": "Grant number",
+            "title": "Grant number", 
             "type": "string"
-          },
+          }, 
           "project_number": {
-            "title": "Project number",
+            "title": "Project number", 
             "type": "string"
           }
-        },
-        "title": "Grant information",
+        }, 
+        "title": "Grant information", 
         "type": "object"
-      },
-      "title": "Funding information",
-      "type": "array",
+      }, 
+      "title": "Funding information", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "hidden_notes": {
-      "description": "FIXME: what about 595__d??",
+      "description": "FIXME: what about 595__d??", 
       "items": {
         "properties": {
-          "cds": {
-            "type": "string"
-          },
-          "cern_reference": {
-            "description": "FIXME: Do we know what this is? do we care?",
-            "type": "string"
-          },
           "source": {
-            "description": "FIXME: What's the semantic of this source?",
+            "description": "FIXME: What's the semantic of this source?", 
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "imprints": {
       "items": {
         "properties": {
           "date": {
-            "format": "date",
+            "format": "date", 
             "type": "string"
-          },
+          }, 
           "place": {
             "type": "string"
-          },
+          }, 
           "publisher": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "isbns": {
       "items": {
         "properties": {
           "comment": {
-            "description": "Further information about type.",
+            "description": "Further information about type.", 
             "type": "string"
-          },
+          }, 
           "medium": {
-            "description": "Medium (type) of the ISBN.",
+            "description": "Medium (type) of the ISBN.", 
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "format": "isbn",
+            "format": "isbn", 
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "value"
-        ],
+        ], 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
+    "keywords": {
+      "items": {
+        "properties": {
+          "classification_scheme": {
+            "type": "string"
+          }, 
+          "keyword": {
+            "type": "string"
+          }, 
+          "source": {
+            "type": "string"
+          }
+        }, 
+        "type": "object"
+      }, 
+      "type": "array", 
+      "uniqueItems": true
+    }, 
     "languages": {
       "items": {
-        "title": "Language",
+        "format": "ISO 639-1", 
+        "pattern": "\\w{2}", 
+        "title": "Language", 
         "type": "string"
-      },
+      }, 
       "type": "array"
-    },
+    }, 
     "license": {
       "items": {
         "properties": {
           "imposing": {
-            "description": "FIXME: what is this!?",
-            "title": "Imposing",
+            "description": "FIXME: what is this!?", 
+            "title": "Imposing", 
             "type": "string"
-          },
+          }, 
           "license": {
-            "title": "License name",
+            "title": "License name", 
             "type": "string"
-          },
+          }, 
           "material": {
-            "title": "Material referred by the license",
+            "title": "Material referred by the license", 
             "type": "string"
-          },
+          }, 
           "url": {
-            "format": "url",
-            "title": "URL of the license",
+            "format": "url", 
+            "title": "URL of the license", 
             "type": "string"
           }
-        },
-        "title": "License",
+        }, 
+        "title": "License", 
         "type": "object"
-      },
-      "title": "License information",
-      "type": "array",
+      }, 
+      "title": "License information", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "new_record": {
+      "$schema": "http://json-schema.org/schema#", 
       "properties": {
         "$ref": {
-          "description": "URL to the referenced resource",
-          "format": "url",
+          "description": "URL to the referenced resource", 
+          "format": "url", 
           "type": "string"
         }
-      },
+      }, 
       "required": [
         "$ref"
-      ],
-      "type": "object",
-      "description": "Master record that replaces this record",
-      "title": "New record"
-    },
+      ], 
+      "type": "object"
+    }, 
     "page_nr": {
       "items": {
-        "description": "FIXME: shall it be integer perhaps?",
-        "title": "Number of pages",
+        "description": "FIXME: shall it be integer perhaps?", 
+        "title": "Number of pages", 
         "type": "string"
-      },
+      }, 
       "type": "array"
-    },
+    }, 
     "persistent_identifiers": {
       "items": {
         "properties": {
           "source": {
-            "description": "Provenance of the persistent identifier",
+            "description": "Provenance of the persistent identifier", 
             "type": "string"
-          },
+          }, 
           "type": {
-            "title": "Type of persistent identifier",
+            "title": "Type of persistent identifier", 
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "title": "Value of the persistent identifier",
+            "title": "Value of the persistent identifier", 
             "type": "string"
           }
-        },
-        "title": "Persistent Identifier",
+        }, 
+        "title": "Persistent Identifier", 
         "type": "object"
-      },
-      "title": "Persistent Identifiers",
-      "type": "array",
+      }, 
+      "title": "Persistent Identifiers", 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "preprint_date": {
-      "format": "date",
+      "format": "date", 
       "type": "string"
-    },
+    }, 
     "public_notes": {
       "items": {
         "properties": {
           "source": {
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "value"
-        ],
+        ], 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "publication_info": {
-      "x_editor_priority": 90,
-      "description": "FIXME: Shall we split conference information away? FIXME: shall we move the DOI and ISBN next to where it belongs? So that we can also align erratum and friends?",
+      "description": "FIXME: Shall we split conference information away? FIXME: shall we move the DOI and ISBN next to where it belongs? So that we can also align erratum and friends?", 
       "items": {
         "properties": {
           "artid": {
-            "description": "Electronic Article ID",
+            "description": "Electronic Article ID", 
             "type": "string"
-          },
+          }, 
           "cnum": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
+            "type": "string"
+          }, 
           "conf_acronym": {
             "type": "string"
-          },
+          }, 
           "conference_record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
-            "type": "object",
-            "description": "URI for corresponding Conference"
-          },
+            ], 
+            "type": "object"
+          }, 
           "confpaper_info": {
             "type": "string"
-          },
+          }, 
           "curated_relation": {
             "type": "boolean"
-          },
+          }, 
           "isbn": {
             "type": "string"
-          },
+          }, 
           "journal_issue": {
             "type": "string"
-          },
+          }, 
           "journal_record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
-            "type": "object",
-            "description": "URI for corresponding Journal"
-          },
+            ], 
+            "type": "object"
+          }, 
           "journal_title": {
             "type": "string"
-          },
+          }, 
           "journal_volume": {
             "type": "string"
-          },
-          "note": {
-            "type": "string"
-          },
+          }, 
+          "notes": {
+            "items": {
+              "type": "string"
+            }, 
+            "type": "array", 
+            "uniqueItems": true
+          }, 
           "page_end": {
-            "description": "Last page",
+            "description": "Last page", 
             "type": "string"
-          },
+          }, 
           "page_start": {
-            "description": "First page",
+            "description": "First page", 
             "type": "string"
-          },
+          }, 
           "parent_record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
-            "type": "object",
-            "description": "URI for the parent this record is part of"
-          },
+            ], 
+            "type": "object"
+          }, 
           "pubinfo_freetext": {
             "type": "string"
-          },
+          }, 
           "reportnumber": {
             "type": "string"
-          },
+          }, 
           "year": {
-            "maximum": 2050,
-            "minimum": 1000,
+            "maximum": 2050, 
+            "minimum": 1000, 
             "type": "integer"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "references": {
       "items": {
-        "description": "record-like Schema for a Publication's reference",
         "properties": {
-          "arxiv_eprints": {
-            "items": {
-              "pattern": "\\d{4}.\\d{4,5}|\\w+-\\w+/\\d+|\\w+/\\d+",
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "authors": {
-            "description": "List with all the authors",
-            "items": {
-              "properties": {
-                "full_name": {
-                  "type": "string",
-                  "x_editor_autocomplete": {
-                    "url": "http://localhost:5000/api/literature/_suggest?size=7&author_name=",
-                    "path": "author_name.0.options",
-                    "size": 7
-                  }
-                },
-                "role": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "x_editor_always_show": true,
-            "title": "Authors",
-            "type": "array",
-            "uniqueItems": true
-          },
-          "book_series": {
-            "properties": {
-              "title": {
-                "description": "Title of the book series",
-                "type": "string"
-              },
-              "volume": {
-                "description": "Specific volume number",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "collaboration": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
           "curated_relation": {
             "type": "boolean"
-          },
-          "dois": {
-            "items": {
-              "pattern": "10\\.\\d+(\\.\\d+)?/.+",
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "imprint": {
-            "properties": {
-              "date": {
-                "format": "date",
-                "type": "string"
-              },
-              "place": {
-                "type": "string"
-              },
-              "publisher": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "misc": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "number": {
-            "description": "Position within the reference list of a record (the number you find in brackets on the PDF).",
-            "type": "integer"
-          },
-          "persistent_identifiers": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Persistent Identifiers",
-            "type": "array",
-            "uniqueItems": true
-          },
-          "publication_info": {
-            "properties": {
-              "artid": {
-                "description": "Electronic Article ID",
-                "type": "string"
-              },
-              "cnum": {
-                "type": "string"
-              },
-              "isbn": {
-                "description": "ISBN",
-                "type": "string"
-              },
-              "journal_issue": {
-                "type": "string"
-              },
-              "journal_title": {
-                "type": "string"
-              },
-              "journal_volume": {
-                "type": "string"
-              },
-              "page_end": {
-                "description": "Last page",
-                "type": "string"
-              },
-              "page_start": {
-                "description": "First page",
-                "type": "string"
-              },
-              "reportnumber": {
-                "type": "string"
-              },
-              "year": {
-                "maximum": 2050,
-                "minimum": 1000,
-                "type": "integer"
-              }
-            },
-            "type": "object"
-          },
-          "raw_reference": {
+          }, 
+          "raw_refs": {
             "items": {
               "properties": {
-                "format": {
-                  "description": "E.g. text, json, xml, bibtex",
+                "position": {
+                  "description": "The position of the reference as it appears on the document", 
                   "type": "string"
-                },
+                }, 
+                "schema": {
+                  "description": "E.g. text, or Elsevier XML, or refexract", 
+                  "type": "string"
+                }, 
                 "source": {
-                  "description": "E.g. refextract, JATS, Elsevier",
                   "type": "string"
-                },
+                }, 
                 "value": {
-                  "x_editor_priority": 50,
                   "type": "string"
                 }
-              },
+              }, 
+              "required": [
+                "value", 
+                "schema"
+              ], 
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "record": {
+            "$schema": "http://json-schema.org/schema#", 
             "properties": {
               "$ref": {
-                "description": "URL to the referenced resource",
-                "format": "url",
+                "description": "URL to the referenced resource", 
+                "format": "url", 
                 "type": "string"
               }
-            },
+            }, 
             "required": [
               "$ref"
-            ],
-            "type": "object",
-            "description": "Referred record"
-          },
-          "texkey": {
-            "title": "INSPIRE Provided texkey.",
-            "type": "string",
-            "x_editor_always_show": true
-          },
-          "titles": {
-            "x_editor_priority": 101,
-            "items": {
-              "properties": {
-                "source": {
+            ], 
+            "type": "object"
+          }, 
+          "reference": {
+            "$schema": "http://json-schema.org/schema#", 
+            "description": "record-like Schema for a Publication's reference", 
+            "properties": {
+              "arxiv_eprints": {
+                "items": {
+                  "pattern": "\\d{4}.\\d{4,5}|\\w+-\\w+/\\d+|\\w+/\\d+", 
                   "type": "string"
-                },
-                "subtitle": {
+                }, 
+                "type": "array", 
+                "uniqueItems": true
+              }, 
+              "authors": {
+                "description": "List with all the authors", 
+                "items": {
+                  "properties": {
+                    "full_name": {
+                      "type": "string"
+                    }, 
+                    "role": {
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                "title": "Authors", 
+                "type": "array", 
+                "uniqueItems": true
+              }, 
+              "book_series": {
+                "properties": {
+                  "title": {
+                    "description": "Title of the book series", 
+                    "type": "string"
+                  }, 
+                  "volume": {
+                    "description": "Specific volume number", 
+                    "type": "string"
+                  }
+                }, 
+                "type": "object"
+              }, 
+              "collaboration": {
+                "items": {
                   "type": "string"
-                },
-                "title": {
+                }, 
+                "type": "array", 
+                "uniqueItems": true
+              }, 
+              "dois": {
+                "items": {
+                  "pattern": "10\\.\\d+(\\.\\d+)?/.+", 
                   "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "urls": {
-            "items": {
-              "properties": {
-                "description": {
+                }, 
+                "type": "array", 
+                "uniqueItems": true
+              }, 
+              "imprint": {
+                "properties": {
+                  "date": {
+                    "format": "date", 
+                    "type": "string"
+                  }, 
+                  "place": {
+                    "type": "string"
+                  }, 
+                  "publisher": {
+                    "type": "string"
+                  }
+                }, 
+                "type": "object"
+              }, 
+              "misc": {
+                "items": {
                   "type": "string"
-                },
-                "value": {
-                  "x_editor_priority": 50,
-                  "format": "url",
+                }, 
+                "type": "array"
+              }, 
+              "number": {
+                "description": "Position within the reference list of a record (the number you find in brackets on the PDF).", 
+                "type": "integer"
+              }, 
+              "persistent_identifiers": {
+                "items": {
                   "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array",
-            "uniqueItems": true
+                }, 
+                "title": "Persistent Identifiers", 
+                "type": "array", 
+                "uniqueItems": true
+              }, 
+              "publication_info": {
+                "properties": {
+                  "artid": {
+                    "description": "Electronic Article ID", 
+                    "type": "string"
+                  }, 
+                  "cnum": {
+                    "type": "string"
+                  }, 
+                  "isbn": {
+                    "description": "ISBN", 
+                    "type": "string"
+                  }, 
+                  "journal_issue": {
+                    "type": "string"
+                  }, 
+                  "journal_title": {
+                    "type": "string"
+                  }, 
+                  "journal_volume": {
+                    "type": "string"
+                  }, 
+                  "page_end": {
+                    "description": "Last page", 
+                    "type": "string"
+                  }, 
+                  "page_start": {
+                    "description": "First page", 
+                    "type": "string"
+                  }, 
+                  "reportnumber": {
+                    "type": "string"
+                  }, 
+                  "year": {
+                    "maximum": 2050, 
+                    "minimum": 1000, 
+                    "type": "integer"
+                  }
+                }, 
+                "type": "object"
+              }, 
+              "texkey": {
+                "description": "INSPIRE Provided texkey.", 
+                "type": "string"
+              }, 
+              "titles": {
+                "items": {
+                  "$schema": "http://json-schema.org/schema#", 
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    }, 
+                    "subtitle": {
+                      "type": "string"
+                    }, 
+                    "title": {
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                "type": "array", 
+                "uniqueItems": true
+              }, 
+              "urls": {
+                "items": {
+                  "$schema": "http://json-schema.org/schema#", 
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    }, 
+                    "value": {
+                      "format": "url", 
+                      "type": "string"
+                    }
+                  }, 
+                  "type": "object"
+                }, 
+                "type": "array", 
+                "uniqueItems": true
+              }
+            }, 
+            "title": "Reference", 
+            "type": "object"
           }
-        },
-        "title": "Reference",
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "report_numbers": {
       "items": {
         "properties": {
           "source": {
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "self": {
+      "$schema": "http://json-schema.org/schema#", 
       "properties": {
         "$ref": {
-          "description": "URL to the referenced resource",
-          "format": "url",
+          "description": "URL to the referenced resource", 
+          "format": "url", 
           "type": "string"
         }
-      },
+      }, 
       "required": [
         "$ref"
-      ],
-      "type": "object",
-      "description": "Url of the record itself",
-      "title": "Url of the record"
-    },
-    "spires_sysnos": {
-      "description": "List of associated legacy SPIRES IDs",
-      "items": {
-        "type": "string"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
+      ], 
+      "type": "object"
+    }, 
     "succeeding_entry": {
-      "description": "Reference to previously merged records.",
+      "description": "Reference to previously merged records.", 
       "properties": {
         "isbn": {
           "type": "string"
-        },
+        }, 
         "record": {
+          "$schema": "http://json-schema.org/schema#", 
           "properties": {
             "$ref": {
-              "description": "URL to the referenced resource",
-              "format": "url",
+              "description": "URL to the referenced resource", 
+              "format": "url", 
               "type": "string"
             }
-          },
+          }, 
           "required": [
             "$ref"
-          ],
+          ], 
           "type": "object"
-        },
+        }, 
         "relationship_code": {
           "type": "string"
         }
-      },
+      }, 
       "type": "object"
-    },
-    "thesaurus_terms": {
-      "items": {
-        "properties": {
-          "classification_scheme": {
-            "type": "string"
-          },
-          "energy_range": {
-            "description": "FIXME: What... is... that!?",
-            "maximum": 9,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "keyword": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
+    }, 
     "thesis": {
       "properties": {
         "date": {
-          "format": "date",
+          "format": "date", 
           "type": "string"
-        },
+        }, 
         "defense_date": {
-          "format": "date",
+          "format": "date", 
           "type": "string"
-        },
+        }, 
         "degree_type": {
-          "description": "FIXME: this enum must be reviewed",
           "enum": [
-            "PhD",
-            "Master",
-            "Bachelor",
-            "Diploma",
-            "Habilitation",
-            "Laurea",
-            "Thesis"
-          ],
+            "Other", 
+            "Internship Report", 
+            "Diploma", 
+            "Bachelor", 
+            "Laurea", 
+            "Master", 
+            "Thesis", 
+            "PhD", 
+            "Habilitation"
+          ], 
           "type": "string"
-        },
+        }, 
         "institutions": {
           "items": {
             "properties": {
               "curated_relation": {
                 "type": "boolean"
-              },
+              }, 
               "name": {
                 "type": "string"
-              },
+              }, 
               "record": {
+                "$schema": "http://json-schema.org/schema#", 
                 "properties": {
                   "$ref": {
-                    "description": "URL to the referenced resource",
-                    "format": "url",
+                    "description": "URL to the referenced resource", 
+                    "format": "url", 
                     "type": "string"
                   }
-                },
+                }, 
                 "required": [
                   "$ref"
-                ],
-                "type": "object",
-                "description": "URI of the matched insitution record."
+                ], 
+                "type": "object"
               }
-            },
+            }, 
             "type": "object"
-          },
+          }, 
           "type": "array"
         }
-      },
+      }, 
       "type": "object"
-    },
+    }, 
     "thesis_supervisors": {
       "items": {
         "properties": {
@@ -1258,132 +1365,101 @@
               "properties": {
                 "curated_relation": {
                   "type": "boolean"
-                },
+                }, 
                 "record": {
+                  "$schema": "http://json-schema.org/schema#", 
                   "properties": {
                     "$ref": {
-                      "description": "URL to the referenced resource",
-                      "format": "url",
+                      "description": "URL to the referenced resource", 
+                      "format": "url", 
                       "type": "string"
                     }
-                  },
+                  }, 
                   "required": [
                     "$ref"
-                  ],
+                  ], 
                   "type": "object"
-                },
+                }, 
                 "value": {
-                  "x_editor_priority": 50,
                   "type": "string"
                 }
-              },
+              }, 
               "type": "object"
-            },
+            }, 
             "type": "array"
-          },
+          }, 
           "full_name": {
             "type": "string"
           }
-        },
+        }, 
         "required": [
           "full_name"
-        ],
+        ], 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
+    }, 
     "title_translations": {
       "items": {
         "properties": {
+          "language": {
+            "format": "ISO 639-1", 
+            "pattern": "\\w{2}", 
+            "type": "string"
+          }, 
           "source": {
             "type": "string"
-          },
+          }, 
           "subtitle": {
             "type": "string"
-          },
+          }, 
           "title": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
-    "title_variations": {
-      "items": {
-        "properties": {
-          "source": {
-            "type": "string"
-          },
-          "subtitle": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
+    }, 
     "titles": {
-      "x_editor_priority": 101,
       "items": {
+        "$schema": "http://json-schema.org/schema#", 
         "properties": {
           "source": {
             "type": "string"
-          },
+          }, 
           "subtitle": {
             "type": "string"
-          },
+          }, 
           "title": {
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
-    },
-    "titles_old": {
-      "items": {
-        "properties": {
-          "source": {
-            "type": "string"
-          },
-          "subtitle": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
+    }, 
     "urls": {
       "items": {
+        "$schema": "http://json-schema.org/schema#", 
         "properties": {
           "description": {
             "type": "string"
-          },
+          }, 
           "value": {
-            "x_editor_priority": 50,
-            "format": "url",
+            "format": "url", 
             "type": "string"
           }
-        },
+        }, 
         "type": "object"
-      },
-      "type": "array",
+      }, 
+      "type": "array", 
       "uniqueItems": true
     }
-  },
-  "title": "Publication",
+  }, 
+  "title": "Publication", 
   "type": "object"
 }

--- a/src/any-type-field/any-type-field.component.html
+++ b/src/any-type-field/any-type-field.component.html
@@ -1,0 +1,17 @@
+<div [ngSwitch]="componentType">
+	<div *ngSwitchCase="'table-list'">
+		<table-list-field [values]="value" (onValuesChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></table-list-field>
+	</div>
+	<div *ngSwitchCase="'complex-list'">
+		<complex-list-field [values]="value" (onValuesChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></complex-list-field>
+	</div>
+	<div *ngSwitchCase="'primitive-list'">
+		<primitive-list-field [values]="value" (onValuesChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></primitive-list-field>
+	</div>
+	<div *ngSwitchCase="'object'">
+		<object-field [value]="value" (onValueChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></object-field>
+	</div>
+	<div *ngSwitchDefault>
+		<primitive-field [value]="value" (onValueChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></primitive-field>
+	</div>
+</div>

--- a/src/any-type-field/any-type-field.component.ts
+++ b/src/any-type-field/any-type-field.component.ts
@@ -20,32 +20,45 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-
-import { AbstractListFieldComponent } from '../abstract-list-field';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 
 import {
-  AppGlobalsService,
-  EmptyValueService
+  ComponentTypeService,
 } from '../shared/services';
 
+/**
+ * AnyFieldComponent
+ * 
+ * This is a dummy component that has no logic, just passes @Input to its child and
+ * propagates its child's output to its parent.
+ * 
+ * IMPORTANT: 
+ * On the other hand it has smart template which has logic to decide which type of 
+ * component to use according to schema.
+ */
 @Component({
-  selector: 'complex-list-field',
+  selector: 'any-type-field',
   styleUrls: [
-    './complex-list-field.component.scss'
+    './any-type-field.component.scss'
   ],
-  templateUrl: './complex-list-field.component.html'
+  templateUrl: './any-type-field.component.html'
 })
-export class ComplexListFieldComponent extends AbstractListFieldComponent {
+export class AnyTypeFieldComponent {
 
-  @Input() values: Array<Object>;
+  @Input() value: any;
   @Input() schema: Object;
   @Input() path: string;
 
-  @Output() onValuesChange: EventEmitter<Array<Object>> = new EventEmitter<Array<Object>>();
+  @Output() onValueChange: EventEmitter<any> = new EventEmitter<any>();
 
-  constructor(public emptyValueService: EmptyValueService,
-    public appGlobalsService: AppGlobalsService) {
-    super();
+  constructor(public componentTypeService: ComponentTypeService) { }
+
+  get componentType(): string {
+    return this.componentTypeService.getComponentType(this.schema);
   }
 }

--- a/src/any-type-field/index.ts
+++ b/src/any-type-field/index.ts
@@ -1,0 +1,1 @@
+export { AnyTypeFieldComponent } from './any-type-field.component';

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -1,45 +1,33 @@
 <div [id]="path">
-  <div>
-    <table class="table table-bordered">
-      <tbody *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
-        <tr *ngFor="let row of value | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
-          <td class="label-holder">
-            <div>
-              <strong>{{row.key | underscoreToSpace}}</strong>
-            </div>
-          </td>
-          <td>
-            <div [ngSwitch]="getFieldType(row.key)">
-              <div *ngSwitchCase="'object'">
-                <object-field [value]="value[row.key]" (onValueChange)="onValueChange($event, i, row.key)" [schema]="schema.items.properties[row.key]" [path]="getValuePath(i, row.key)"></object-field>
-              </div>
-              <div *ngSwitchCase="'table-list'">
-                <table-list-field [values]="value[row.key]" (onValuesChange)="onValueChange($event, i, row.key)" [schema]="schema.items.properties[row.key]" [path]="getValuePath(i, row.key)"></table-list-field>
-              </div>
-              <div *ngSwitchCase="'primitive-list'">
-                <primitive-list-field [values]="value[row.key]" (onValuesChange)="onValueChange($event, i, row.key)" [schema]="schema.items.properties[row.key]" [path]="getValuePath(i, row.key)"></primitive-list-field>
-              </div>
-              <div *ngSwitchDefault>
-                <primitive-field [value]="value[row.key]" (onValueChange)="onValueChange($event, i, row.key)" [schema]="schema.items.properties[row.key]" [path]="getValuePath(i, row.key)"></primitive-field>
-              </div>
-            </div>
-          </td>
-        </tr>
-        <!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
-        <tr *ngIf="values.length > 0">
-          <td class="button-holder">
-            <add-field-to-object-dropdown [(value)]="values[i]" [schema]="schema.items.properties"></add-field-to-object-dropdown>
-          </td>
-          <td class="button-holder">
-            <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
-            <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
-            <button *ngIf="i < (values.length - 1)" class="editor-btn-move-down" type="button" (click)="moveElement(i, 1)">▼</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="add-new-field-container">
-    <button type="button" class="btn-new-field" (click)="addNewElement()">+</button>
-  </div>
+	<div>
+		<table class="table table-bordered">
+			<tbody *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
+				<tr *ngFor="let row of value | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
+					<td class="label-holder">
+						<div>
+							<strong>{{row.key | underscoreToSpace}}</strong>
+						</div>
+					</td>
+					<td>
+						<any-type-field [value]="value[row.key]" (onValueChange)="onValueChange($event, i, row.key)" [schema]="schema.items.properties[row.key]"
+							[path]="getValuePath(i, row.key)"></any-type-field>
+					</td>
+				</tr>
+				<!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
+				<tr *ngIf="values.length > 0">
+					<td class="button-holder">
+						<add-field-to-object-dropdown [(value)]="values[i]" [schema]="schema.items.properties"></add-field-to-object-dropdown>
+					</td>
+					<td class="button-holder">
+						<button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
+						<button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
+						<button *ngIf="i < (values.length - 1)" class="editor-btn-move-down" type="button" (click)="moveElement(i, 1)">▼</button>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<div class="add-new-field-container">
+		<button type="button" class="btn-new-field" (click)="addNewElement()">+</button>
+	</div>
 </div>

--- a/src/json-editor.component.html
+++ b/src/json-editor.component.html
@@ -1,38 +1,23 @@
 <div class="editor-container">
-    <div class="editor-table-container">
-        <table id="editor" class="table table-striped">
-            <tr *ngFor="let pair of record | mapToSortedIterable:schema.properties; trackBy:trackByFunction">
-                <td class="label-holder">
-                    <label>{{pair.key | underscoreToSpace}}</label>
-                </td>
-                <td>
-                    <div [ngSwitch]="getFieldType(pair.key)">
-                        <div *ngSwitchCase="'table-list'">
-                            <table-list-field [values]="pair.value" (onValuesChange)="onValueChange($event, pair.key)" [schema]="schema.properties[pair.key]" [path]="pair.key"></table-list-field>
-                        </div>
-                        <div *ngSwitchCase="'complex-list'">
-                            <complex-list-field [values]="pair.value" (onValuesChange)="onValueChange($event, pair.key)" [schema]="schema.properties[pair.key]" [path]="pair.key"></complex-list-field>
-                        </div>
-                        <div *ngSwitchCase="'primitive-list'">
-                            <primitive-list-field [values]="pair.value" (onValuesChange)="onValueChange($event, pair.key)" [schema]="schema.properties[pair.key]" [path]="pair.key"></primitive-list-field>
-                        </div>
-                        <div *ngSwitchCase="'object'">
-                            <object-field [value]="pair.value" (onValueChange)="onValueChange($event, pair.key)" [schema]="schema.properties[pair.key]" [path]="pair.key"></object-field>
-                        </div>
-                        <div *ngSwitchDefault>
-                            <primitive-field [value]="record[pair.key]" (onValueChange)="onValueChange($event, pair.key)" [schema]="schema.properties[pair.key]" [path]="pair.key"></primitive-field>
-                        </div>
-                    </div>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <div class="right-side-container">
-        <div>
-            <tree-menu [record]="record" [schema]="schema"></tree-menu>
-        </div>
-        <div>
-            <editor-previewer [previews]="previews"> </editor-previewer>
-        </div>
-    </div>
+	<div class="editor-table-container">
+		<table id="editor" class="table table-striped">
+			<tr *ngFor="let pair of record | mapToSortedIterable:schema.properties; trackBy:trackByFunction">
+				<td class="label-holder">
+					<label>{{pair.key | underscoreToSpace}}</label>
+				</td>
+				<td>
+					<any-type-field [value]="record[pair.key]" (onValueChange)="onValueChange($event, pair.key)" [schema]="schema.properties[pair.key]"
+						[path]="pair.key"></any-type-field>
+				</td>
+			</tr>
+		</table>
+	</div>
+	<div class="right-side-container">
+		<div>
+			<tree-menu [record]="record" [schema]="schema"></tree-menu>
+		</div>
+		<div>
+			<editor-previewer [previews]="previews"> </editor-previewer>
+		</div>
+	</div>
 </div>

--- a/src/json-editor.component.ts
+++ b/src/json-editor.component.ts
@@ -81,8 +81,6 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnC
     if (Object.keys(this.record).length === 0) { return; }
 
     this.record = this.recordFixerService.fixRecord(this.record, this.schema);
-    this.record = this.jsonUtilService.flattenMARCJson(this.record, this.schema);
-    this.schema = this.jsonUtilService.flattenMARCSchema(this.schema);
     this.previews = this.extractPreviews();
     this.appGlobalsService.globalErrors = this.errorMap;
   }

--- a/src/json-editor.module.ts
+++ b/src/json-editor.module.ts
@@ -33,6 +33,7 @@ import {
   AddFieldToListDropdownComponent,
   AddFieldToObjectDropdownComponent
 } from './add-field-dropdown';
+import { AnyTypeFieldComponent } from './any-type-field';
 import { AutocompleteInputComponent } from './autocomplete-input';
 import { ComplexListFieldComponent } from './complex-list-field';
 import { EditorPreviewerComponent } from './editor-previewer';
@@ -41,7 +42,10 @@ import { ObjectFieldComponent } from './object-field';
 import { PrimitiveListFieldComponent } from './primitive-list-field';
 import { PrimitiveFieldComponent } from './primitive-field';
 import { TableListFieldComponent } from './table-list-field';
-import { TreeMenuComponent, TreeMenuItemComponent } from './tree-menu';
+import {
+  TreeMenuComponent,
+  TreeMenuItemComponent
+} from './tree-menu';
 import { SearchableDropdownComponent } from './searchable-dropdown';
 
 import { SHARED_PIPES, SHARED_SERVICES } from './shared';
@@ -52,6 +56,7 @@ import { SHARED_PIPES, SHARED_SERVICES } from './shared';
     ...SHARED_PIPES,
     AddFieldToListDropdownComponent,
     AddFieldToObjectDropdownComponent,
+    AnyTypeFieldComponent,
     AutocompleteInputComponent,
     ComplexListFieldComponent,
     ObjectFieldComponent,

--- a/src/object-field/object-field.component.html
+++ b/src/object-field/object-field.component.html
@@ -7,7 +7,7 @@
         </div>
       </td>
       <td>
-        <primitive-field [value]="value[row.key]" (onValueChange)="onPropertyChange($event, row.key)" [schema]=schema.properties[row.key] [path]="getFieldPath(row.key)"></primitive-field>
+        <any-type-field [value]="value[row.key]" (onValueChange)="onPropertyChange($event, row.key)" [schema]=schema.properties[row.key] [path]="getFieldPath(row.key)"></any-type-field>
       </td>
       <td class="button-holder">
         <button type="button" class="editor-btn-delete" (click)="deleteField(row.key)">&times;</button>

--- a/src/shared/pipes/map-to-sorted-iterable.pipe.spec.ts
+++ b/src/shared/pipes/map-to-sorted-iterable.pipe.spec.ts
@@ -140,4 +140,26 @@ describe('MapToSortedIterablePipe', () => {
       expect(pipe.transform(map, schema.properties)).toEqual(expected);
     });
 
+  it('should not return hidden keys', () => {
+    let schema = {
+      properties: {
+        key1: {
+          x_editor_hidden: true
+        },
+        key2: {
+        }
+      }
+    };
+    let map = {
+      key1: 'value1',
+      key2: 'value2'
+    };
+
+    let expected = [
+      new Pair('key2', 'value2'),
+    ];
+
+    expect(pipe.transform(map, schema.properties)).toEqual(expected);
+  });
+
 });

--- a/src/shared/pipes/map-to-sorted-iterable.pipe.ts
+++ b/src/shared/pipes/map-to-sorted-iterable.pipe.ts
@@ -31,15 +31,17 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class MapToSortedIterablePipe implements PipeTransform {
 
   /**
-   * Transforms an object to sorted array of key-value pairs of its properties.
+   * Transforms an object to sorted (by `x_editor_priority`) array of key-value pairs of its properties.
+   * Also it filters out the fields for which `x_editor_hidden` is set.
    * 
    * @param {Object} map - the object to be transformed
-   * @param {Object} schema - the `schema.propeties` of the object to be used for sorting
+   * @param {Object} schema - the `schema.propeties` of the object, used for sorting and filtering
    * @return {Array<Pair<any>>} - sorted array of key-value pairs of given map's properties.
    */
   transform(map: Object, schema: Object): Array<Pair> {
     if (!map) { return undefined; }
     return Object.keys(map)
+      .filter(key => !schema[key]['x_editor_hidden'])
       .sort((a, b) => {
         // Sort by x_editor_priority, larger is the first.
         let pa = schema[a]['x_editor_priority'] || 0;

--- a/src/shared/services/component-type.service.ts
+++ b/src/shared/services/component-type.service.ts
@@ -38,6 +38,10 @@ export class ComponentTypeService {
    * @return {string}
    */
   getComponentType(schema: Object): string {
+    if (!schema) {
+      throw new Error('schema is undefined');
+    }
+
     if (schema['x_editor_disabled']) {
       return 'disabled';
     } else if (schema['x_editor_autocomplete']) {
@@ -48,7 +52,13 @@ export class ComponentTypeService {
 
     let schemaType = schema['type'];
     if (!schemaType) {
-      return 'raw';
+      if (schema['anyOf']) {
+        return 'any-of';
+      } else if (Object.keys(schema).length === 0) { // if shema === {} (empty object)
+        return 'raw';
+      } else {
+        throw new Error(`Not supported schema: ${JSON.stringify(schema)}`);
+      }
     } else if (schemaType === 'array') {
       let itemSchema = schema['items'];
       if (itemSchema['type'] === 'object') {
@@ -66,6 +76,7 @@ export class ComponentTypeService {
           return 'table-list';
         }
       } else {
+        // if schema.items.type is not object!
         return 'primitive-list';
       }
     }

--- a/src/shared/services/json-util.service.ts
+++ b/src/shared/services/json-util.service.ts
@@ -21,7 +21,6 @@
 */
 
 import { Injectable } from '@angular/core';
-import { ComponentTypeService } from './component-type.service';
 
 /**
  * WARNING: this doesn't work when the root json object is an array!
@@ -29,8 +28,6 @@ import { ComponentTypeService } from './component-type.service';
  */
 @Injectable()
 export class JsonUtilService {
-
-  private componentTypeService: ComponentTypeService = new ComponentTypeService();
 
   /**
    * Returns value of the property located in dot separated path of json.
@@ -42,157 +39,5 @@ export class JsonUtilService {
       value = value[pathElement];
     });
     return value;
-  }
-
-  /**
-   * FIXME: shallow flattening!
-   */
-  flattenMARCSchema(schema: Object): Object {
-    Object.keys(schema['properties'])
-      .filter(field => this.componentTypeService
-        .getComponentType(schema['properties'][field]) === 'table-list')
-      .forEach(field => {
-        let elementSchema = schema['properties'][field]['items'];
-        Object.keys(elementSchema['properties'])
-          .filter(elementProp => elementSchema['properties'][elementProp]['type'] === 'object')
-          .forEach(objectElementProp => {
-            Object.keys(elementSchema['properties'][objectElementProp]['properties'])
-              .forEach(prop => {
-                elementSchema['properties'][`${objectElementProp}.${prop}`] =
-                  elementSchema['properties'][objectElementProp]['properties'][prop];
-              });
-            delete elementSchema['properties'][objectElementProp];
-          });
-      });
-    return schema;
-  }
-
-  /**
-   * TODO: add example input and output to the function doc!
-   * 
-   * @param {Object} jsonObject - The marc json object to be flattened.
-   */
-  flattenMARCJson(jsonObject: Object, schema: Object): Object {
-    return this.modifyMARCJson(jsonObject, schema['properties'], new JsonFlattener());
-  }
-
-  /**
-   * TODO: add example input and output to the function doc!
-   * 
-   * @param {Object} jsonObject - The marc json object to be unflattened.
-   */
-  unflattenMARCJson(jsonObject: Object, schema: Object): Object {
-    return this.modifyMARCJson(jsonObject, schema['properties'], new JsonUnFlattener());
-  }
-
-  /**
-   * This skips top level properties (MARC fields)
-   * and array type properties of the top level properties 
-   *  (MARC subfields with array of objects as a property)
-   * and apply the given operator to all the rest.
-   * 
-   * @param {Object} jsonObject - The marc json object to be flattened.
-   * @param {Object} schema - The schema to be used to determine 
-   *  if a property of the jsonObject should be flattened, (schema.properties)
-   * @param {JsonOperator} jsonOperator - The operator to be applied to given json object
-   * 
-   */
-  private modifyMARCJson(jsonObject: Object, schema: Object, jsonOperator: JsonOperator): Object {
-    const modifiedJson = {};
-    // TODO: create multiple instances of JsonOperator inside forEach function 
-    //  if this operation should be parallel
-    // FIXME: doesn't flatten table-list in complex-list
-    Object.keys(jsonObject)
-      .forEach(prop => {
-        switch (this.componentTypeService.getComponentType(schema[prop])) {
-          case 'table-list':
-            modifiedJson[prop] = [];
-            jsonObject[prop].forEach((element, i) => {
-              modifiedJson[prop][i] = jsonOperator.apply(element, schema[prop]['items']);
-            });
-            break;
-          case 'object':
-            modifiedJson[prop] = jsonOperator.apply(jsonObject[prop], schema[prop]);
-            break;
-          default:
-            modifiedJson[prop] = jsonObject[prop];
-        }
-      });
-    return modifiedJson;
-  }
-}
-
-
-/**
- * Single function utility interface
- */
-interface JsonOperator {
-  apply(jsonObject: Object, schema?: Object): Object;
-}
-
-/**
- * Single function utility class for flattening a json object
- * 
- * @extends JsonOperator
- */
-class JsonFlattener implements JsonOperator {
-  private result: Object;
-
-  /**
-   * Flattens only objects!
-   * 
-   * @param {Object} jsonObject - The json object to be flattened. 
-   * @param {Object} schema - The json schema to be flattened.
-   */
-  apply(jsonObject: Object, schema: Object): Object {
-    this.result = {};
-    this.recurse(jsonObject, '', schema);
-    return this.result;
-  }
-
-  private recurse(cur, prop, schema) {
-    switch (schema['type']) {
-      case 'object':
-        const keys = Object.keys(cur);
-        if (keys.length === 0) {
-          this.result[prop] = {};
-        } else {
-          keys.forEach(p =>
-            this.recurse(cur[p], prop ? `${prop}.${p}` : p, schema['properties'][p]));
-        }
-        break;
-      default:
-        this.result[prop] = cur;
-    }
-  }
-}
-
-/**
- * Single function utility class for unflattening a json object
- * 
- * @extends JsonOperator
- */
-class JsonUnFlattener implements JsonOperator {
-  /** 
-   * @param {Object} jsonObject - The json object to be unflattened. 
-   * @param {Object} schema - NOT USED!
-   */
-  apply(jsonObject: Object, schema: Object): Object {
-    const json = {};
-    Object.keys(jsonObject).forEach(p => {
-      let cur = json;
-      let prop = '';
-      let last = 0;
-      let idx;
-      do {
-        idx = p.indexOf('.', last);
-        const temp = p.substring(last, idx !== -1 ? idx : undefined);
-        cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp, 10)) ? [] : {}));
-        prop = temp;
-        last = idx + 1;
-      } while (idx >= 0);
-      cur[prop] = jsonObject[p];
-    });
-    return { json: json[''] };
   }
 }

--- a/src/shared/services/record-fixer.service.spec.ts
+++ b/src/shared/services/record-fixer.service.spec.ts
@@ -110,6 +110,7 @@ describe('RecordFixerService', () => {
           level1: {
             type: 'array',
             items: {
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -141,6 +142,7 @@ describe('RecordFixerService', () => {
           level1: {
             type: 'array',
             items: {
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -207,88 +209,6 @@ describe('RecordFixerService', () => {
       let everythingMissingRecord = {};
       let fixedEverythingMissingRecord = service.fixRecord(everythingMissingRecord, schema);
       expect(fixedEverythingMissingRecord['prop0'][0]['prop1'][0]['prop2']['prop3']).toBeDefined();
-    }
-  );
-
-  it('should delete properties that are marked as x_editor_hidden in a record with depth 1',
-    () => {
-      let schema = {
-        properties: {
-          prop: {
-            type: 'string',
-            x_editor_hidden: true
-          }
-        }
-      };
-
-      let record = {
-        prop: 'value'
-      };
-
-      let fixedRecord = service.fixRecord(record, schema);
-
-      expect(fixedRecord['prop']).not.toBeDefined();
-    }
-  );
-
-  it('should delete properties that are marked as x_editor_hidden in a record with depth 2',
-    () => {
-      let schema = {
-        properties: {
-          level1: {
-            type: 'object',
-            properties: {
-              prop: {
-                type: 'string',
-                x_editor_hidden: true
-              }
-            }
-          }
-        }
-      };
-
-      let record = {
-        level1: {
-          prop: 'value'
-        }
-      };
-
-      let fixedRecord = service.fixRecord(record, schema);
-
-      expect(fixedRecord['level1']['prop']).not.toBeDefined();
-    }
-  );
-
-  it('should delete properties that are marked as x_editor_hidden' +
-    ' in a record with depth 2 and array parent',
-    () => {
-      let schema = {
-        properties: {
-          level1: {
-            type: 'array',
-            items: {
-              properties: {
-                prop: {
-                  type: 'string',
-                  x_editor_hidden: true
-                }
-              },
-              type: 'object'
-            }
-          }
-        }
-      };
-
-      let record = {
-        level1: [
-          { prop: 'value1' },
-          { prop: 'value2' }
-        ]
-      };
-
-      let fixedRecord = service.fixRecord(record, schema);
-      fixedRecord['level1'].forEach((element => expect(element['prop']).not.toBeDefined()));
-
     }
   );
 

--- a/src/shared/services/record-fixer.service.ts
+++ b/src/shared/services/record-fixer.service.ts
@@ -110,7 +110,6 @@ export class RecordFixerService {
    */
   private fix(key: string | number, parent: Object | Array<any>, schema: Object) {
     if (schema['x_editor_hidden']) {
-      delete parent[key];
       return;
     }
 
@@ -151,12 +150,17 @@ export class RecordFixerService {
    */
   private fixTableList(array: Array<Object>, schema: Object) {
     let presentKeys = {};
-
+    let itemSchema;
+    if (schema['items']['anyOf']) {
+      itemSchema = schema['items']['anyOf'][0];
+    } else {
+      itemSchema = schema['items'];
+    }
     // 1. Step
     array.forEach(element => {
       Object.keys(element)
         // Don't include  if not part of schema, will be deleted anyway.
-        .filter(key => schema['items']['properties'][key])
+        .filter(key => itemSchema['properties'][key])
         .forEach(key => {
           presentKeys[key] = true;
         });
@@ -165,7 +169,7 @@ export class RecordFixerService {
     // 2. Step
     Object.keys(presentKeys).forEach(key => {
       let emptyElement = this.emptyValueService
-        .generateEmptyValue(schema['items']['properties'][key]);
+        .generateEmptyValue(itemSchema['properties'][key]);
       array.filter(element => !element[key])
         .forEach(element => {
           element[key] = emptyElement;

--- a/src/table-list-field/table-list-field.component.html
+++ b/src/table-list-field/table-list-field.component.html
@@ -1,47 +1,39 @@
 <div [id]="path">
-  <div>
-    <table class="table table-bordered editable-inner-table">
-      <thead class="thead-inverse">
-        <tr>
-          <th *ngFor="let column of values[0] | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
-            {{column.key}}
-          </th>
+	<div>
+		<table class="table table-bordered editable-inner-table">
+			<thead class="thead-inverse">
+				<tr>
+					<th *ngFor="let column of values[0] | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
+						{{column.key}}
+					</th>
 
-          <th class="button-holder">
-              <add-field-to-list-dropdown *ngIf="values[0]" [(values)]="values" [value]="values[0]" [schema]="schema.items.properties"></add-field-to-list-dropdown>
-          </th>
+					<th class="button-holder">
+						<add-field-to-list-dropdown *ngIf="values[0]" [(values)]="values" [value]="values[0]" [schema]="schema.items.properties"></add-field-to-list-dropdown>
+					</th>
 
-        </tr>
-      </thead>
-      <tr *ngFor="let row of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
-        <!-- Element value -->
-        <td *ngFor="let column of row | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
-          <div [ngSwitch]="getFieldType(column.key)">
-            <div *ngSwitchCase="'primitive-list'" class="list-holder">
-              <primitive-list-field [values]="row[column.key]" (onValuesChange)="onValueChange($event, i, column.key)" [schema]="schema.items.properties[column.key]" [path]="getValuePath(i, column.key)"></primitive-list-field>
-            </div>
-            <div *ngSwitchCase="'object'">
-              <object-field [value]="row[column.key]" (onValueChange)="onValueChange($event, i, column.key)" [schema]="schema.items.properties[column.key]" [path]="getValuePath(i, column.key)"></object-field>
-            </div>
-            <div *ngSwitchDefault>
-              <primitive-field [value]="row[column.key]" (onValueChange)="onValueChange($event, i, column.key)" [schema]="schema.items.properties[column.key]" [path]="getValuePath(i, column.key)"></primitive-field>
-            </div>
-          </div>
-        </td>
+				</tr>
+			</thead>
+			<tr *ngFor="let row of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
+				<!-- Element value -->
+				<td *ngFor="let column of row | mapToSortedIterable:schema.items.properties; trackBy:trackByFunction">
+						<any-type-field [value]="row[column.key]" (onValueChange)="onValueChange($event, i, column.key)" [schema]="schema.items.properties[column.key]"
+							[path]="getValuePath(i, column.key)"></any-type-field>
 
-        <!-- UP/DOWN and DELETE buttons for each row -->
-        <td *ngIf="values.length > 0" class="button-holder">
-            <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
-            <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
-            <button *ngIf="i < (values.length - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">▼</button>
-        </td>
-      </tr>
-      <tr>
-      </tr>
-    </table>
-  </div>
-  <div class="add-new-field-container">
-    <!-- ADD button for table -->
-    <button type="button" class="btn-new-field" (click)="addNewElement()">+</button>
-  </div>
-</div>
+				</td>
+
+				<!-- UP/DOWN and DELETE buttons for each row -->
+				<td *ngIf="values.length > 0" class="button-holder">
+					<button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
+					<button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
+					<button *ngIf="i < (values.length - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">▼</button>
+				</td>
+			</tr>
+			<tr>
+			</tr>
+		</table>
+		</div>
+		<div class="add-new-field-container">
+			<!-- ADD button for table -->
+			<button type="button" class="btn-new-field" (click)="addNewElement()">+</button>
+		</div>
+	</div>

--- a/src/table-list-field/table-list-field.component.ts
+++ b/src/table-list-field/table-list-field.component.ts
@@ -26,7 +26,6 @@ import { AbstractListFieldComponent } from '../abstract-list-field';
 
 import {
   AppGlobalsService,
-  ComponentTypeService,
   EmptyValueService
 } from '../shared/services';
 
@@ -45,8 +44,7 @@ export class TableListFieldComponent extends AbstractListFieldComponent {
 
   @Output() onValuesChange: EventEmitter<Array<Object>> = new EventEmitter<Array<Object>>();
 
-  constructor(private componentTypeService: ComponentTypeService,
-    public emptyValueService: EmptyValueService,
+  constructor(public emptyValueService: EmptyValueService,
     public appGlobalsService: AppGlobalsService) {
     super();
   }
@@ -69,12 +67,6 @@ export class TableListFieldComponent extends AbstractListFieldComponent {
         clone[prop] = this.emptyValueService.generateEmptyValue(propSchema);
       });
     return Object.assign({}, clone);
-  }
-
-  // TODO: cache the types for each field!
-  getFieldType(field: string): string {
-    let fieldSchema = this.schema['items']['properties'][field];
-    return this.componentTypeService.getComponentType(fieldSchema);
   }
 
 }


### PR DESCRIPTION
* Adds any-type-field component to share template code which decides
what component to use according to the schema.

* Increases json type coverage such as object in an object, array in
array

* Move x_editor_hidden handling into mapToSortedIterable pipe.
(referencing #37)

* Removes flattening/unflattening (referencing #37).

* Updates mock-data to latest version schema and record of Inspire.