### PR TITLE
add limited support for anyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then add it to your module's `imports`.
 ```
 
 - `config` : configuration object. See [configuration section](#configuration) for options.
-- `schema` : valid json-schema for the record.
+- `schema` : valid json-schema for the record. See [json schema limitations](#json-schema-limitations)
 - `record` : valid json to be edited.
 - `onRecordChange` emitted when record change, `$event` is the edited record.
 - `errorMap (={})`: errors for individual parts of the record (format should be [errors-map.json](./example/assets/mock-data/error-map.json) 
@@ -136,6 +136,14 @@ Configuration for previews to be displayed in previewer (on the right side).
   }
 ]
 ```
+
+## <a name="json-schema-limitations"></a>Json Schema Limitations
+
+### anyOf
+
+`ng2-json-editor` has very limited support for `anyOf`, support where all `anyOf` items have same properties
+and they are objects with primitive properties. Before display, it picks the first `anyOf` item, merges all enum values and
+removes `pattern` and `format` rules.
 
 # DEVELOPMENT
 

--- a/src/shared/services/schema-fixer.service.spec.ts
+++ b/src/shared/services/schema-fixer.service.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * This file is part of ng2-json-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * ng2-json-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * ng2-json-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ng2-json-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+
+import { SchemaFixerService } from './schema-fixer.service';
+import { JsonUtilService } from './json-util.service';
+
+describe('SchemaFixerService', () => {
+
+  let service: SchemaFixerService;
+
+  beforeEach(() => {
+    service = new SchemaFixerService(new JsonUtilService);
+  });
+
+  it('should fix anyOf with multiple enum properties', () => {
+    let schema = {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            enumProp1: {
+              type: 'string',
+              enum: [
+                'enumProp11',
+                'enumProp12'
+              ]
+            },
+            enumProp2: {
+              type: 'string',
+              enum: [
+                'enumProp21',
+                'enumProp22'
+              ]
+            }
+          }
+        },
+        {
+          type: 'object',
+          properties: {
+            enumProp1: {
+              type: 'string',
+              enum: [
+                'enumProp13',
+                'enumProp14'
+              ]
+            },
+            enumProp2: {
+              type: 'string',
+              enum: [
+                'enumProp23',
+                'enumProp24'
+              ]
+            }
+          }
+        }
+      ]
+    };
+    let expected = {
+      type: 'object',
+      properties: {
+        enumProp1: {
+          type: 'string',
+          enum: [
+            'enumProp11',
+            'enumProp12',
+            'enumProp13',
+            'enumProp14'
+          ]
+        },
+        enumProp2: {
+          type: 'string',
+          enum: [
+            'enumProp21',
+            'enumProp22',
+            'enumProp23',
+            'enumProp24'
+          ]
+        }
+      }
+    };
+    let fixed = service.fixSchema(schema, {});
+    expect(fixed).toEqual(expected);
+  });
+
+  it('should enrich schema with config', () => {
+    let schema = {
+      type: 'object',
+      properties: {
+        parent: {
+          type: 'object',
+          properties: {
+            prop: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    };
+    let config = {
+      'parent.properties.prop': {
+        configTrue: true,
+        configFalse: false
+      }
+    };
+    let expected = {
+      type: 'object',
+      properties: {
+        parent: {
+          type: 'object',
+          properties: {
+            prop: {
+              type: 'string',
+              configTrue: true,
+              configFalse: false
+            }
+          }
+        }
+      }
+    };
+    let fixed = service.fixSchema(schema, config);
+    expect(fixed).toEqual(expected);
+  });
+});

--- a/src/shared/services/schema-fixer.service.ts
+++ b/src/shared/services/schema-fixer.service.ts
@@ -30,17 +30,86 @@ export class SchemaFixerService {
   constructor(private jsonUtilService: JsonUtilService) { }
 
   /**
-   * Enriches schema with options coming from configuration
+   * Fixes schema to be in a format that expected by json-editor
    * 
-   * @param {Object} schema - schema for the record
+   * @param {Object} schema - json schema
    * @param {Object} config - schema specific options
-   * @return {Object} - fixed record
+   * @return {Object} - fixed schema
    */
   fixSchema(schema: Object, config: Object): Object {
+
+    this.enrichSchemaWithConfig(schema, config);
+    schema = this.fixRecursively(schema);
+    return schema;
+  }
+
+  /**
+   * Enriches given schema with given configuration objects
+   * puts config into correct places in schema.
+   * 
+   * @param {Object} schema - json schema
+   * @param {Object} config - schema specific options
+   */
+  private enrichSchemaWithConfig(schema: Object, config: Object) {
     Object.keys(config).forEach(field => {
       let schemaField = this.jsonUtilService.getValueInPath(schema['properties'], field);
       Object.assign(schemaField, config[field]);
     });
+  }
+  /**
+   * Applies all fixes to schema recursively
+   */
+  private fixRecursively(schema: Object): Object {
+    if (schema['anyOf']) {
+      schema = this.fixAnyOf(schema);
+    }
+    // schema fixes must be done above
+
+    // recursively call for deeper parts of schema
+    if (schema['properties']) {
+      Object.keys(schema['properties'])
+        .forEach(prop => {
+          schema['properties'][prop] = this.fixRecursively(schema['properties'][prop]);
+        });
+    } else if (schema['items']) {
+      schema['items'] = this.fixRecursively(schema['items']);
+    }
     return schema;
   }
+
+  /**
+   * Fixes anyOf schemas with exactly same property structure
+   * it merges all enum fields in anyOf elements
+   */
+  private fixAnyOf(schema: Object): Object {
+    let anyOf: Array<Object> = schema['anyOf'];
+    // find enum types
+    let anyOfProps = anyOf[0]['properties'];
+    let enumPropNames = Object.keys(anyOfProps)
+      .filter(prop => anyOfProps[prop]['enum']);
+    // concat enum values for each enum property
+    let enums = {};
+    anyOf.forEach(anyOfElement => {
+      enumPropNames.forEach(propName => {
+        if (!enums[propName]) {
+          enums[propName] = [];
+        }
+        enums[propName] = enums[propName].concat(anyOfElement['properties'][propName]['enum']);
+      });
+    });
+    let fixedSchema = anyOf[0];
+    // shallow cleaning of format and pattern
+    Object.keys(fixedSchema['properties'])
+      .forEach(prop => {
+        delete fixedSchema['properties'][prop]['format'];
+        delete fixedSchema['properties'][prop]['pattern'];
+      });
+    // merge all values of each enum property
+    enumPropNames.forEach(propName => {
+      // use Set to have unique values
+      fixedSchema['properties'][propName]['enum'] = Array.from(new Set(enums[propName]));
+    });
+    return fixedSchema;
+  }
+
 }


### PR DESCRIPTION
* Adds anyOf support where all anyOf items have same properties
and are objects. Picks the first one, merges all enum values and
removes patter and format rules.

* Adds tests for schema-fixer service

Shall we add the info about limitation of this support (like in the commit message) to somewhere
in README?
@jmartinm 