### PR TITLE
implement customizable $ref field

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ Shortcut map for enum fields, to map shorthand values to enum values
 
 So when `a` typed in enum field and enter is pressed, enum field value will be set to `Another value in enum array`.
 
+#### <a name="x_editor_ref_config"></a>x_editor_ref_config
+
+Config for objects that has `$ref` string as a property which points to another json.
+
+```
+{
+  template: string; (html template where you can access json that is pointed by $ref by using 'context')
+  lazy: boolean; (flag to indicate if template should be rendered on request or on page load, a preview button is inserted if set true)
+}
+```
+
+Example template:
+```
+<div>aValue: {{(context | async)?.aValue}}<div>
+```
+
+Note that:
+
+- you have to use async pipe since the Observable passed as context.
+- you can use other angular2 common pipes such as `lowercase`, `json` etc.
+
 ### <a name="previews"></a>Previews
 
 Configuration for previews to be displayed in previewer (on the right side).
@@ -149,6 +170,12 @@ Configuration for previews to be displayed in previewer (on the right side).
   }
 ]
 ```
+
+### $ref fields
+
+These are object fields which has `$ref` string value that points to another json (remote or local).
+
+If you don't configure [like here](#x_editor_ref_config) it will be displayed as a clickable, not editable `$ref` link that opens to the link in a new tab.
 
 ## <a name="json-schema-limitations"></a>Json Schema Limitations
 

--- a/src/any-type-field/any-type-field.component.html
+++ b/src/any-type-field/any-type-field.component.html
@@ -11,6 +11,9 @@
 	<div *ngSwitchCase="'object'">
 		<object-field [value]="value" (onValueChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></object-field>
 	</div>
+	<div *ngSwitchCase="'ref'">
+		<ref-field [refValue]="value.get('$ref')" [schema]="schema" [path]="path"></ref-field>
+	</div>
 	<div *ngSwitchDefault>
 		<primitive-field [value]="value" (onValueChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></primitive-field>
 	</div>

--- a/src/json-editor.module.ts
+++ b/src/json-editor.module.ts
@@ -39,6 +39,7 @@ import { JsonEditorComponent } from './json-editor.component';
 import { ObjectFieldComponent } from './object-field';
 import { PrimitiveListFieldComponent } from './primitive-list-field';
 import { PrimitiveFieldComponent } from './primitive-field';
+import { RefFieldComponent } from './ref-field';
 import { TableListFieldComponent } from './table-list-field';
 import {
   TreeMenuComponent,
@@ -61,6 +62,7 @@ import { SHARED_PIPES, SHARED_SERVICES } from './shared';
     EditorPreviewerComponent,
     PrimitiveListFieldComponent,
     PrimitiveFieldComponent,
+    RefFieldComponent,
     SearchableDropdownComponent,
     TableListFieldComponent,
     TreeMenuItemComponent,

--- a/src/ref-field/index.ts
+++ b/src/ref-field/index.ts
@@ -1,0 +1,1 @@
+export { RefFieldComponent } from './ref-field.component';

--- a/src/ref-field/ref-field.component.html
+++ b/src/ref-field/ref-field.component.html
@@ -1,0 +1,8 @@
+<div [id]="path" [ngSwitch]="shouldDisplayWithTemplate" >
+  <div *ngSwitchCase="true">
+    <button class="btn-preview-template" *ngIf="isLazy" (click)="onPreviewClick($event)">👁</button>
+  </div>
+  <div *ngSwitchDefault>
+    <a target="_blank" [href]="refValue">{{refValue}}</a>
+  </div>
+</div>

--- a/src/ref-field/ref-field.component.scss
+++ b/src/ref-field/ref-field.component.scss
@@ -1,0 +1,6 @@
+button.btn-preview-template {
+  background: transparent;
+  border: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/ref-field/ref-field.component.ts
+++ b/src/ref-field/ref-field.component.ts
@@ -1,0 +1,71 @@
+/*
+ * This file is part of ng2-json-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * ng2-json-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * ng2-json-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ng2-json-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import { Component, Input, OnInit, ViewContainerRef } from '@angular/core';
+import { Http } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+
+import { DynamicTemplateLoaderService } from '../shared/services';
+
+@Component({
+  selector: 'ref-field',
+  styleUrls: [
+    './ref-field.component.scss'
+  ],
+  templateUrl: './ref-field.component.html'
+})
+export class RefFieldComponent implements OnInit {
+
+  @Input() schema: Object;
+  @Input() refValue: string;
+  @Input() path: string;
+
+  refData$: Observable<Object>;
+  isLazy: boolean;
+  customTemplate: string;
+  shouldDisplayWithTemplate: boolean = false;
+
+  constructor(private viewContainer: ViewContainerRef,
+    private http: Http,
+    private dynamicTemplateLoaderService: DynamicTemplateLoaderService) { }
+
+  ngOnInit() {
+    if (this.schema['x_editor_ref_config']) {
+      this.isLazy = this.schema['x_editor_ref_config']['lazy'];
+      this.customTemplate = this.schema['x_editor_ref_config']['template'];
+      this.shouldDisplayWithTemplate = Boolean(this.customTemplate && this.refValue);
+      if (this.shouldDisplayWithTemplate) {
+        this.refData$ = this.http
+          .get(this.refValue)
+          .map(res => res.json());
+        if (!this.isLazy) {
+          this.dynamicTemplateLoaderService.loadTemplate(this.customTemplate, this.refData$, this.viewContainer);
+        }
+      }
+    }
+  }
+
+  onPreviewClick(event: Event) {
+    this.dynamicTemplateLoaderService.loadTemplate(this.customTemplate, this.refData$, this.viewContainer);
+    (event.target as HTMLElement).remove();
+  }
+}

--- a/src/shared/services/component-type.service.spec.ts
+++ b/src/shared/services/component-type.service.spec.ts
@@ -88,9 +88,22 @@ describe('ComponentTypeService', () => {
 
   it('should return object', () => {
     let schema = {
-      type: 'object'
+      type: 'object',
+      properties: {}
     };
     expect(service.getComponentType(schema)).toEqual('object');
+  });
+
+  it('should return ref', () => {
+    let schema = {
+      type: 'object',
+      properties: {
+        $ref: {
+          type: 'string'
+        }
+      }
+    };
+    expect(service.getComponentType(schema)).toEqual('ref');
   });
 
   it('should return autocomplete', () => {

--- a/src/shared/services/component-type.service.ts
+++ b/src/shared/services/component-type.service.ts
@@ -55,6 +55,10 @@ export class ComponentTypeService {
       if (Object.keys(schema).length === 0) { // if shema === {} (empty object)
         return 'raw';
       }
+    } else if (schemaType === 'object') {
+      if (schema['properties']['$ref']) {
+        return 'ref';
+      }
     } else if (schemaType === 'array') {
       let itemSchema = schema['items'];
       if (itemSchema['type'] === 'object') {

--- a/src/shared/services/dynamic-template-loader.service.ts
+++ b/src/shared/services/dynamic-template-loader.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, Compiler, ViewContainerRef, Component, NgModule, ComponentFactory } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Injectable()
+export class DynamicTemplateLoaderService {
+
+  // cache for component factories for templates
+  private cache: Map<string, ComponentFactory<any>> = new Map();
+
+  constructor(private compiler: Compiler) { }
+
+  /**
+   * Creates a dummy component with given template and context
+   * and inserts it in given view container.
+   * 
+   * @param {string} template - html template string
+   * @param {any} context - context data which is referenced in `template` as `context`
+   * @param {ViewContainerRef} viewContainer - view container where the template will inserted
+   */
+  public loadTemplate(template: string, context: any, viewContainer: ViewContainerRef) {
+    // check if factory for dummy component is created before for the template
+    if (this.cache.has(template)) {
+      let component = viewContainer.createComponent(this.cache.get(template));
+      component.instance.context = context;
+      return;
+    }
+
+    // dummy component with given template
+    @Component({ template: template })
+    class DynamicTemplateComponent { }
+
+    // dummy module that wraps dummy component and CommonModule (for core pipes such as async)
+    @NgModule({
+      declarations: [DynamicTemplateComponent],
+      imports: [CommonModule]
+    })
+    class DynamicTemplateModule { }
+
+    // compile the module in runtime which will create the factory for dummy component
+    this.compiler.compileModuleAndAllComponentsAsync(DynamicTemplateModule)
+      .then(module => module.componentFactories
+        .find(factory => factory.componentType === DynamicTemplateComponent))
+      .then(factory => {
+        this.cache.set(template, factory);
+        let component = viewContainer.createComponent(factory);
+        component.instance.context = context;
+        component.changeDetectorRef.markForCheck();
+      });
+  }
+}

--- a/src/shared/services/index.ts
+++ b/src/shared/services/index.ts
@@ -2,6 +2,7 @@ import { AppGlobalsService } from './app-globals.service';
 import { AutocompletionService } from './autocompletion.service';
 import { ComponentTypeService } from './component-type.service';
 import { DomUtilService } from './dom-util.service';
+import { DynamicTemplateLoaderService } from './dynamic-template-loader.service';
 import { EmptyValueService } from './empty-value.service';
 import { JsonUtilService } from './json-util.service';
 import { RecordFixerService } from './record-fixer.service';
@@ -14,6 +15,7 @@ export {
   AutocompletionService,
   ComponentTypeService,
   DomUtilService,
+  DynamicTemplateLoaderService,
   EmptyValueService,
   JsonUtilService,
   RecordFixerService,
@@ -27,6 +29,7 @@ export const SHARED_SERVICES = [
   AutocompletionService,
   ComponentTypeService,
   DomUtilService,
+  DynamicTemplateLoaderService,
   EmptyValueService,
   JsonUtilService,
   RecordFixerService,


### PR DESCRIPTION
* Adds dynamic-templater-loader service that can compile and load angular2 templates
into DOM in runtime by wrapping them with a dummy component and a
module.(referencing #45)

* Adds ref-field component that handles the object field with $ref
inside using the template in x_editor_ref_config from schema.