### PR TITLE
On change cb config

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,29 @@ Config for objects that has `$ref` string as a property which points to another 
 {
   template: string; (html template where you can access json that is pointed by $ref by using 'context')
   lazy: boolean; (flag to indicate if template should be rendered on request or on page load, a preview button is inserted if set true)
+  headers?: Array<Object>; (array of headers which will be used for http request that fetches the $ref data)
 }
 ```
 
-Example template:
+Example `template`:
 ```
 <div>aValue: {{(context | async)?.aValue}}<div>
+```
+
+Example `headers`:
+```
+[
+  { 'Accept': 'application/json' },
+  { 'Custom': 'custom-header-value' },
+  ...
+]
 ```
 
 Note that:
 
 - you have to use async pipe since the Observable passed as context.
 - you can use other angular2 common pipes such as `lowercase`, `json` etc.
+- you can access the error during http request, via `context.error`.  
 
 #### x_editor_on_value_change
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ with configuration object that has the following properties below.
   url?: string; (remote source url that returns the autocompletion results)
   path?: string; (path to array of autocompletion results in response from the url, separated by dot '.')
   source?: Array<string>; (source array that will be used to autocomplete locally)
+  onCompletionSelect?: function(path: Array<any>, completion: [AutocompletionResult](./src/typings.d.ts), store: [NestedStore](./src/typings.d.ts));
+    (function to be called when a completion results is selected)
   size: number; (maximum number of items to be showed)
 }
 ```
@@ -158,6 +160,28 @@ Note that:
 
 - you have to use async pipe since the Observable passed as context.
 - you can use other angular2 common pipes such as `lowercase`, `json` etc.
+
+#### x_editor_on_value_change
+
+Function that will be called when the value of configured property is changed.
+This function can access the whole json thanks to [`store`](./src/shared/services/json-store.service.ts), and 
+can change all other properties if required.
+
+```
+function(path: Array<any>, value: any, store: NestedStore)
+```
+
+Example function:
+
+```
+(path, value, store) => {
+  // do stuff with params here
+}
+```
+
+Note that:
+
+- JsonStoreService's `getIn` and `setIn` returns and takes `immutable.js`'s `List` and `Map` instead of `Array` and `Object`
 
 ### <a name="previews"></a>Previews
 

--- a/src/abstract-field/abstract-field.component.ts
+++ b/src/abstract-field/abstract-field.component.ts
@@ -39,16 +39,19 @@ export abstract class AbstractFieldComponent
   extends AbstractTrackerComponent
   implements OnInit, OnDestroy {
 
-  path: string;
+  path: Array<any>;
   errors: Array<Object> = [];
   errorsSubsciption: Subscription;
-  appGlobalsService: AppGlobalsService;
+
+  constructor(public appGlobalsService: AppGlobalsService) {
+    super();
+  }
 
   ngOnInit() {
     this.errorsSubsciption = this.appGlobalsService
       .globalErrorsSubject
       .subscribe((globalErrors) => {
-        this.errors = globalErrors[this.path] || [];
+        this.errors = globalErrors[this.path.join('.')] || [];
       });
   }
 

--- a/src/abstract-field/abstract-field.component.ts
+++ b/src/abstract-field/abstract-field.component.ts
@@ -41,14 +41,14 @@ export abstract class AbstractFieldComponent
 
   path: Array<any>;
   errors: Array<Object> = [];
-  errorsSubsciption: Subscription;
+  errorsSubscription: Subscription;
 
   constructor(public appGlobalsService: AppGlobalsService) {
     super();
   }
 
   ngOnInit() {
-    this.errorsSubsciption = this.appGlobalsService
+    this.errorsSubscription = this.appGlobalsService
       .globalErrorsSubject
       .subscribe((globalErrors) => {
         this.errors = globalErrors[this.path.join('.')] || [];
@@ -56,8 +56,8 @@ export abstract class AbstractFieldComponent
   }
 
   ngOnDestroy() {
-    if (this.errorsSubsciption) {
-      this.errorsSubsciption.unsubscribe();
+    if (this.errorsSubscription) {
+      this.errorsSubscription.unsubscribe();
     }
   }
 

--- a/src/abstract-list-field/abstract-list-field.component.ts
+++ b/src/abstract-list-field/abstract-list-field.component.ts
@@ -20,11 +20,11 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { EventEmitter } from '@angular/core';
-
 import { List } from 'immutable';
 
 import { AbstractFieldComponent } from '../abstract-field';
+
+import { JsonStoreService, AppGlobalsService } from '../shared/services';
 
 /**
  * Abstract component to share code of common operations of all array fields
@@ -36,23 +36,12 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
 
   values: List<any>;
   schema: Object;
-  onValuesChange: EventEmitter<List<any>>;
-  path: string;
+  path: Array<any>;
 
-  /**
-   * Called when a property of any element of the values is changed
-   * Used if values is a object array.
-   * 
-   * @param {any} value - new value
-   * @param {number} index - index of changed element in array
-   * @param {key} key - name of the changed property of the element in given index
-   * 
-   */
-  onValueChange(value: any, index: number, key: string) {
-    this.values = this.values.setIn([index, key], value);
-    this.onValuesChange.emit(this.values);
+  constructor(public appGlobalsService: AppGlobalsService,
+    public jsonStoreService: JsonStoreService) {
+    super(appGlobalsService);
   }
-
   /**
    * @param {number} index - Index of the element that is moved
    * @param {number} direction - Movement direction. -1 for UP, +1 for DOWN
@@ -63,22 +52,22 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
     this.values = this.values
       .set(index, this.values.get(newIndex))
       .set(newIndex, temp);
-    this.onValuesChange.emit(this.values);
+    this.jsonStoreService.setIn(this.path, this.values);
   }
 
   /**
    * @param {number} index - Index of the element to be deleted
    */
   deleteElement(index: number) {
-    this.values = this.values.remove(index);
-    this.onValuesChange.emit(this.values);
+    this.jsonStoreService.setIn(this.path, this.values.remove(index));
+    this.values = this.jsonStoreService.getIn(this.path);
   }
 
   /**
    * Returns path of the property of an element at index.
    */
-  getValuePath(index: number, property: string): string {
-    return `${this.path}.${index}.${property}`;
+  getValuePath(index: number, property: string): Array<any> {
+    return this.path.concat(index, property);
   }
 
 }

--- a/src/add-field-dropdown/add-field-dropdown.component.html
+++ b/src/add-field-dropdown/add-field-dropdown.component.html
@@ -1,12 +1,12 @@
 <div *ngIf="!disabled" class="btn-group" dropdown keyboardNav="true" (onToggle)="focusElementIfOpen($event, expressionInput)">
-	<button id="simple-btn-keyboard-nav" type="button" class="editor-btn-add-subfield" dropdownToggle>+ <span class="caret"></span></button>
-	<ul class="dropdown-menu" dropdownMenu aria-labelledby="simple-btn-keyboard-nav">
-		<li>
-			<input #expressionInput class="dropdown-filter" [(ngModel)]="expression" placeholder="filter">
-		</li>
-		<li class="divider dropdown-divider"></li>
-		<li *ngFor="let key of schema | differentKeys:fields | filterByExpression:expression">
-			<a class="dropdown-item" href="javascript:void(0)" (click)="onFieldAdd.emit(key)">{{key}}</a>
-		</li>
-	</ul>
+  <button id="simple-btn-keyboard-nav" type="button" class="editor-btn-add-subfield" dropdownToggle>+ <span class="caret"></span></button>
+  <ul class="dropdown-menu" dropdownMenu aria-labelledby="simple-btn-keyboard-nav">
+    <li>
+      <input #expressionInput class="dropdown-filter" [(ngModel)]="expression" placeholder="filter">
+    </li>
+    <li class="divider dropdown-divider"></li>
+    <li *ngFor="let key of schema | differentKeys:fields | filterByExpression:expression">
+      <a class="dropdown-item" href="javascript:void(0)" (click)="onFieldAdd.emit(key)">{{key}}</a>
+    </li>
+  </ul>
 </div>

--- a/src/add-new-element-button/add-new-element-button.component.html
+++ b/src/add-new-element-button/add-new-element-button.component.html
@@ -1,3 +1,3 @@
 <div class="button-container">
-	<button tooltipHtml="<b>Add new {{key | underscoreToSpace}}</b>" type="button" class="btn-new-field" (click)="addNewElement()">+</button>
+  <button tooltipHtml="<b>Add new {{tooltipName | underscoreToSpace}}</b>" type="button" class="btn-new-field" (click)="addNewElement()">+</button>
 </div>

--- a/src/add-new-element-button/add-new-element-button.component.ts
+++ b/src/add-new-element-button/add-new-element-button.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 import { List } from 'immutable';
 
-import { EmptyValueService } from '../shared/services';
+import { EmptyValueService, JsonStoreService } from '../shared/services';
 
 @Component({
   selector: 'add-new-element-button',
@@ -14,19 +14,21 @@ import { EmptyValueService } from '../shared/services';
 })
 export class AddNewElementButtonComponent {
 
-  @Input() key: string;
-  @Input() values: List<any>;
+  @Input() path: Array<any>;
   @Input() schema: Object;
 
-  @Output() onNewElementAdd: EventEmitter<any> = new EventEmitter<any>();
+  constructor(public emptyValueService: EmptyValueService,
+    public jsonStoreService: JsonStoreService) { }
 
-  constructor(private emptyValueService: EmptyValueService) { }
+  get tooltipName(): string {
+    return this.path[this.path.length - 1];
+  }
 
   addNewElement() {
     let itemSchema = this.schema['items'];
     let emptyValue = this.emptyValueService.generateEmptyValue(itemSchema);
-    this.values = this.values.push(emptyValue);
-    this.onNewElementAdd.emit(this.values);
+    let values = this.jsonStoreService.getIn(this.path) || List.of([]);
+    this.jsonStoreService.setIn(this.path, values.push(emptyValue));
   }
 
 }

--- a/src/any-type-field/any-type-field.component.html
+++ b/src/any-type-field/any-type-field.component.html
@@ -12,7 +12,7 @@
     <object-field [value]="value" [schema]="schema" [path]="path"></object-field>
   </div>
   <div *ngSwitchCase="'ref'">
-    <ref-field [refValue]="value.get('$ref')" [schema]="schema" [path]="path"></ref-field>
+    <ref-field [value]="value" [schema]="schema" [path]="path"></ref-field>
   </div>
   <div *ngSwitchCase="'value-change-watcher'">
     <value-change-watcher [value]="value" [schema]="schema" [path]="path"></value-change-watcher>

--- a/src/any-type-field/any-type-field.component.html
+++ b/src/any-type-field/any-type-field.component.html
@@ -1,20 +1,23 @@
 <div [ngSwitch]="componentType">
-	<div *ngSwitchCase="'table-list'">
-		<table-list-field [values]="value" [schema]="schema" [path]="path"></table-list-field>
-	</div>
-	<div *ngSwitchCase="'complex-list'">
-		<complex-list-field [values]="value" [schema]="schema" [path]="path"></complex-list-field>
-	</div>
-	<div *ngSwitchCase="'primitive-list'">
-		<primitive-list-field [values]="value" [schema]="schema" [path]="path"></primitive-list-field>
-	</div>
-	<div *ngSwitchCase="'object'">
-		<object-field [value]="value" [schema]="schema" [path]="path"></object-field>
-	</div>
-	<div *ngSwitchCase="'ref'">
-		<ref-field [refValue]="value.get('$ref')" [schema]="schema" [path]="path"></ref-field>
-	</div>
-	<div *ngSwitchDefault>
-		<primitive-field [value]="value" [schema]="schema" [path]="path"></primitive-field>
-	</div>
+  <div *ngSwitchCase="'table-list'">
+    <table-list-field [values]="value" [schema]="schema" [path]="path"></table-list-field>
+  </div>
+  <div *ngSwitchCase="'complex-list'">
+    <complex-list-field [values]="value" [schema]="schema" [path]="path"></complex-list-field>
+  </div>
+  <div *ngSwitchCase="'primitive-list'">
+    <primitive-list-field [values]="value" [schema]="schema" [path]="path"></primitive-list-field>
+  </div>
+  <div *ngSwitchCase="'object'">
+    <object-field [value]="value" [schema]="schema" [path]="path"></object-field>
+  </div>
+  <div *ngSwitchCase="'ref'">
+    <ref-field [refValue]="value.get('$ref')" [schema]="schema" [path]="path"></ref-field>
+  </div>
+  <div *ngSwitchCase="'value-change-watcher'">
+    <value-change-watcher [value]="value" [schema]="schema" [path]="path"></value-change-watcher>
+  </div>
+  <div *ngSwitchDefault>
+    <primitive-field [value]="value" [schema]="schema" [path]="path"></primitive-field>
+  </div>
 </div>

--- a/src/any-type-field/any-type-field.component.html
+++ b/src/any-type-field/any-type-field.component.html
@@ -1,20 +1,20 @@
 <div [ngSwitch]="componentType">
 	<div *ngSwitchCase="'table-list'">
-		<table-list-field [values]="value" (onValuesChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></table-list-field>
+		<table-list-field [values]="value" [schema]="schema" [path]="path"></table-list-field>
 	</div>
 	<div *ngSwitchCase="'complex-list'">
-		<complex-list-field [values]="value" (onValuesChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></complex-list-field>
+		<complex-list-field [values]="value" [schema]="schema" [path]="path"></complex-list-field>
 	</div>
 	<div *ngSwitchCase="'primitive-list'">
-		<primitive-list-field [values]="value" (onValuesChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></primitive-list-field>
+		<primitive-list-field [values]="value" [schema]="schema" [path]="path"></primitive-list-field>
 	</div>
 	<div *ngSwitchCase="'object'">
-		<object-field [value]="value" (onValueChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></object-field>
+		<object-field [value]="value" [schema]="schema" [path]="path"></object-field>
 	</div>
 	<div *ngSwitchCase="'ref'">
 		<ref-field [refValue]="value.get('$ref')" [schema]="schema" [path]="path"></ref-field>
 	</div>
 	<div *ngSwitchDefault>
-		<primitive-field [value]="value" (onValueChange)="onValueChange.emit($event)" [schema]="schema" [path]="path"></primitive-field>
+		<primitive-field [value]="value" [schema]="schema" [path]="path"></primitive-field>
 	</div>
 </div>

--- a/src/any-type-field/any-type-field.component.ts
+++ b/src/any-type-field/any-type-field.component.ts
@@ -22,15 +22,11 @@
 
 import {
   Component,
-  EventEmitter,
   Input,
-  Output,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
 } from '@angular/core';
 
-import {
-  ComponentTypeService,
-} from '../shared/services';
+import { ComponentTypeService } from '../shared/services';
 
 /**
  * AnyFieldComponent
@@ -52,11 +48,9 @@ import {
 })
 export class AnyTypeFieldComponent {
 
-  @Input() value: any;
   @Input() schema: Object;
-  @Input() path: string;
-
-  @Output() onValueChange: EventEmitter<any> = new EventEmitter<any>();
+  @Input() path: Array<any>;
+  @Input() value: any;
 
   constructor(public componentTypeService: ComponentTypeService) { }
 

--- a/src/autocomplete-input/autocomplete-input.component.html
+++ b/src/autocomplete-input/autocomplete-input.component.html
@@ -1,4 +1,4 @@
 <div>
   <input [ngModel]="value" (ngModelChange)="onModelChange($event)" [typeahead]="dataSource" [typeaheadOptionsLimit]="autocompletionOptions.size"
-    [typeaheadOptionField]="typeaheadOptionField" [typeaheadWaitMs]="200" placeholder="{{placeholder}}">
+    [typeaheadOptionField]="typeaheadOptionField" (typeaheadOnSelect)="onCompletionSelect($event.item)" [typeaheadWaitMs]="200" placeholder="{{placeholder}}">
 </div>

--- a/src/autocomplete-input/autocomplete-input.component.spec.ts
+++ b/src/autocomplete-input/autocomplete-input.component.spec.ts
@@ -33,14 +33,14 @@ import { Ng2BootstrapModule } from 'ng2-bootstrap/ng2-bootstrap';
 
 import { AutocompleteInputComponent } from '../autocomplete-input';
 
-import { RemoteAutocompletionService } from '../shared/services';
+import { RemoteAutocompletionService, JsonStoreService } from '../shared/services';
 
 const autocompletionServiceResults = [
   { text: 'Result1' },
   { text: 'Result2' },
   { text: 'Result3' }
 ];
-class MockAutocompletionService extends RemoteAutocompletionService {
+class MockRemoteAutocompletionService extends RemoteAutocompletionService {
   getAutocompletionResults(options: AutocompletionOptions,
     token: string): Observable<Array<AutocompletionResult>> {
     return Observable.of(autocompletionServiceResults);
@@ -63,7 +63,8 @@ describe('AutocompleteInputComponent', () => {
         HttpModule
       ],
       providers: [
-        RemoteAutocompletionService
+        { provide: RemoteAutocompletionService, useClass: MockRemoteAutocompletionService },
+        JsonStoreService
       ]
     }).compileComponents();
   }));
@@ -77,6 +78,7 @@ describe('AutocompleteInputComponent', () => {
       url: '',
       path: '',
       size: 3,
+      onCompletionSelect: (path, completion, store) => {}
     };
     component.value = '';
     fixture.detectChanges();

--- a/src/autocomplete-input/autocomplete-input.component.ts
+++ b/src/autocomplete-input/autocomplete-input.component.ts
@@ -22,9 +22,10 @@
 
 import { Component, EventEmitter, Input, OnInit, Output, ChangeDetectionStrategy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+
 import 'rxjs/add/observable/of';
 
-import { RemoteAutocompletionService } from '../shared/services';
+import { JsonStoreService, RemoteAutocompletionService } from '../shared/services';
 
 @Component({
   selector: 'autocomplete-input',
@@ -37,23 +38,27 @@ import { RemoteAutocompletionService } from '../shared/services';
 export class AutocompleteInputComponent implements OnInit {
 
   @Input() autocompletionOptions: AutocompletionOptions;
+  @Input() path: Array<any>;
   @Input() value: string;
   @Input() placeholder: string;
 
-  @Output() onValueChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() onValueChange: EventEmitter<string> = new EventEmitter<any>();
 
   dataSource: Observable<string> | Array<string>;
   typeaheadOptionField: string;
 
-  constructor(private remoteAutocompletionService: RemoteAutocompletionService) { }
+  constructor(public remoteAutocompletionService: RemoteAutocompletionService,
+    public jsonStoreService: JsonStoreService) { }
 
   ngOnInit() {
     // if url option set then use remote autocompletion service
     if (this.autocompletionOptions.url) {
       this.typeaheadOptionField = 'text';
       this.dataSource = Observable.create((observer: any) => {
-        // Runs on every search
-        observer.next(this.value);
+        // Runs on every 
+        if (this.value && this.value.length > 0) {
+          observer.next(this.value);
+        }
       }).mergeMap((token: string) =>
         this.remoteAutocompletionService.getAutocompletionResults(this.autocompletionOptions, token));
     } else {
@@ -65,5 +70,14 @@ export class AutocompleteInputComponent implements OnInit {
   onModelChange(value: string) {
     this.value = value;
     this.onValueChange.emit(value);
+  }
+
+  onCompletionSelect(completionItem: AutocompletionResult) {
+    let onCompletionSelect = this.autocompletionOptions.onCompletionSelect;
+    // if callback set and it is remote autocompletion source
+    if (onCompletionSelect && this.typeaheadOptionField) {
+      // .slice() is used to pass by value instead of reference
+      onCompletionSelect(this.path.slice(), completionItem, this.jsonStoreService);
+    }
   }
 }

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -1,32 +1,31 @@
-<div [id]="path">
-	<div *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i" >
-		<div class="complex-list-field-wrapper">
-			<table class="table">
-				<tr *ngFor="let key of keys[i] | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
-					<td class="label-holder">
-						<div>
-							<label>{{key | underscoreToSpace}}</label>
-							<add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [key]="key" [schema]="schema.items.properties[key]"
-								[values]="value.get(key) | selfOrEmpty:schema.items.properties[key]" (onNewElementAdd)="onValueChange($event, i, key)"></add-new-element-button>
-						</div>
-					</td>
-					<td>
-						<any-type-field [value]="value.get(key) | selfOrEmpty:schema.items.properties[key]" (onValueChange)="onValueChange($event, i, key)" [schema]="schema.items.properties[key]"
-							[path]="getValuePath(i, key)"></any-type-field>
-					</td>
-				</tr>
-				<!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
-				<tr *ngIf="values.size > 0">
-						<td class="button-holder">
-							<add-field-dropdown [fields]="keys[i]" (onFieldAdd)="onFieldAdd($event, i)" [schema]="schema.items.properties"></add-field-dropdown>
-						</td>
-						<td class="button-holder button-holder-complex-list-actions">
-							<button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(i)">&times;</button>
-							<button *ngIf="i > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(i, -1)">▲</button>
-							<button *ngIf="i < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(i, 1)">▼</button>
-						</td>
-				</tr>
-			</table>
-		</div>
-	</div>
+<div [id]="path.join('.')">
+  <div *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path.join('.') + '.' + i">
+    <div class="complex-list-field-wrapper">
+      <table class="table">
+        <tr *ngFor="let key of keys[i] | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
+          <td class="label-holder">
+            <div>
+              <label>{{key | underscoreToSpace}}</label>
+              <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(i, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
+            </div>
+          </td>
+          <td>
+            <any-type-field [value]="value.get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
+              [path]="getValuePath(i, key)"></any-type-field>
+          </td>
+        </tr>
+        <!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
+        <tr *ngIf="values.size > 0">
+          <td class="button-holder">
+            <add-field-dropdown [fields]="keys[i]" (onFieldAdd)="onFieldAdd($event, i)" [schema]="schema.items.properties"></add-field-dropdown>
+          </td>
+          <td class="button-holder button-holder-complex-list-actions">
+            <button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(i)">&times;</button>
+            <button *ngIf="i > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(i, -1)">▲</button>
+            <button *ngIf="i < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(i, 1)">▼</button>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>

--- a/src/complex-list-field/complex-list-field.component.ts
+++ b/src/complex-list-field/complex-list-field.component.ts
@@ -20,16 +20,19 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, EventEmitter, Input, Output, OnChanges, ChangeDetectionStrategy, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  ChangeDetectionStrategy,
+  SimpleChanges
+} from '@angular/core';
 
 import { List, Map } from 'immutable';
 
 import { AbstractListFieldComponent } from '../abstract-list-field';
 
-import {
-  AppGlobalsService,
-  EmptyValueService
-} from '../shared/services';
+import { AppGlobalsService, JsonStoreService } from '../shared/services';
 
 @Component({
   selector: 'complex-list-field',
@@ -43,15 +46,13 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
 
   @Input() values: List<Map<string, any>>;
   @Input() schema: Object;
-  @Input() path: string;
+  @Input() path: Array<any>;
 
   keys: Array<Array<string>>;
 
-  @Output() onValuesChange: EventEmitter<List<Map<string, any>>> = new EventEmitter<any>();
-
-  constructor(public emptyValueService: EmptyValueService,
-    public appGlobalsService: AppGlobalsService) {
-    super();
+  constructor(public appGlobalsService: AppGlobalsService,
+    public jsonStoreService: JsonStoreService) {
+    super(appGlobalsService, jsonStoreService);
   }
 
   onFieldAdd(field: string, index: number) {

--- a/src/json-editor.component.html
+++ b/src/json-editor.component.html
@@ -1,26 +1,25 @@
 <div class="row editor-container">
-	<div class="col-md-2 left">
-		<tree-menu [record]="_record" [schema]="schema"></tree-menu>
-	</div>
-	<div class="col-md-6 middle">
-		<table id="editor" class="table">
-			<div class="field-wrapper" *ngFor="let key of keys | addAlwaysShowFields:schema |filterAndSortBySchema:schema; trackBy:trackByFunction">
-			<tr>
-				<td class="label-holder">
-					<label class="label-top-level">{{key | underscoreToSpace}}</label>
-					<add-new-element-button *ngIf="schema.properties[key].type === 'array'" [key]="key" [schema]="schema.properties[key]" [values]="_record.get(key) | selfOrEmpty:schema.properties[key]"
-						(onNewElementAdd)="onValueChange($event, key)"></add-new-element-button>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<any-type-field [value]="_record.get(key)" (onValueChange)="onValueChange($event, key)" [schema]="schema.properties[key]" [path]="key"></any-type-field>
-				</td>
-			</tr>
-			</div>
-		</table>
-	</div>
-	<div class="col-md-4 right">
-		<editor-previewer [previews]="previews"> </editor-previewer>
-	</div>
+  <div class="col-md-2 left">
+    <tree-menu [record]="_record" [schema]="schema"></tree-menu>
+  </div>
+  <div class="col-md-6 middle">
+    <table id="editor" class="table">
+      <div class="field-wrapper" *ngFor="let key of keys | addAlwaysShowFields:schema |filterAndSortBySchema:schema; trackBy:trackByFunction">
+      <tr>
+        <td class="label-holder">
+          <label class="label-top-level">{{key | underscoreToSpace}}</label>
+          <add-new-element-button *ngIf="schema.properties[key].type === 'array'" [path]="getPathForField(key)" [schema]="schema.properties[key]"></add-new-element-button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <any-type-field [value]="_record.get(key)" [schema]="schema.properties[key]" [path]="getPathForField(key)"></any-type-field>
+        </td>
+      </tr>
+      </div>
+    </table>
+  </div>
+  <div class="col-md-4 right">
+    <editor-previewer [previews]="previews"> </editor-previewer>
+  </div>
 </div>

--- a/src/json-editor.module.ts
+++ b/src/json-editor.module.ts
@@ -37,6 +37,7 @@ import { ComplexListFieldComponent } from './complex-list-field';
 import { EditorPreviewerComponent } from './editor-previewer';
 import { JsonEditorComponent } from './json-editor.component';
 import { ObjectFieldComponent } from './object-field';
+import { ValueChangeWatcherComponent } from './value-change-watcher';
 import { PrimitiveListFieldComponent } from './primitive-list-field';
 import { PrimitiveFieldComponent } from './primitive-field';
 import { RefFieldComponent } from './ref-field';
@@ -60,6 +61,7 @@ import { SHARED_PIPES, SHARED_SERVICES, SHARED_DIRECTIVES } from './shared';
     AutocompleteInputComponent,
     ComplexListFieldComponent,
     ObjectFieldComponent,
+    ValueChangeWatcherComponent,
     EditorPreviewerComponent,
     PrimitiveListFieldComponent,
     PrimitiveFieldComponent,

--- a/src/object-field/object-field.component.html
+++ b/src/object-field/object-field.component.html
@@ -1,26 +1,24 @@
-<div [id]="path">
-	<table class="table">
-		<tr *ngFor="let key of keys | addAlwaysShowFields:schema | filterAndSortBySchema:schema; trackBy:trackByFunction">
-			<td>
-				<div>
-					<label>{{key | underscoreToSpace}}</label>
-					<add-new-element-button *ngIf="schema.properties[key].type === 'array'" [key]="key" [schema]="schema.properties[key]" [values]="value.get(key) | selfOrEmpty:schema.properties[key]"
-						(onNewElementAdd)="onPropertyChange($event, key)"></add-new-element-button>
-				</div>
-			</td>
-			<td>
-				<any-type-field [value]="value.get(key) | selfOrEmpty:schema.properties[key]" (onValueChange)="onPropertyChange($event, key)"
-					[schema]=schema.properties[key] [path]="getFieldPath(key)"></any-type-field>
-			</td>
-			<td class="button-holder">
-				<button type="button" class="editor-btn-delete" (click)="deleteField(key)">&times;</button>
-			</td>
-		</tr>
-		<!-- ADD-FIELD-FROM-SCHEMA -->
-		<tr *ngIf="schema.properties">
-			<td class="button-holder">
-				<add-field-dropdown [fields]="keys" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.properties"></add-field-dropdown>
-			</td>
-		</tr>
-	</table>
+<div [id]="path.join('.')">
+  <table class="table">
+    <tr *ngFor="let key of keys | addAlwaysShowFields:schema | filterAndSortBySchema:schema; trackBy:trackByFunction">
+      <td>
+        <div>
+          <label>{{key | underscoreToSpace}}</label>
+          <add-new-element-button *ngIf="schema.properties[key].type === 'array'" [path]="getFieldPath(key)" [schema]="schema.properties[key]"></add-new-element-button>
+        </div>
+      </td>
+      <td>
+        <any-type-field [value]="value.get(key) | selfOrEmpty:schema.properties[key]" [schema]=schema.properties[key] [path]="getFieldPath(key)"></any-type-field>
+      </td>
+      <td class="button-holder">
+        <button type="button" class="editor-btn-delete" (click)="deleteField(key)">&times;</button>
+      </td>
+    </tr>
+    <!-- ADD-FIELD-FROM-SCHEMA -->
+    <tr *ngIf="schema.properties">
+      <td class="button-holder">
+        <add-field-dropdown [fields]="keys" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.properties"></add-field-dropdown>
+      </td>
+    </tr>
+  </table>
 </div>

--- a/src/object-field/object-field.component.ts
+++ b/src/object-field/object-field.component.ts
@@ -20,13 +20,13 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, EventEmitter, Input, Output, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
 import { Map } from 'immutable';
 
 import { AbstractFieldComponent } from '../abstract-field';
 
-import { AppGlobalsService } from '../shared/services';
+import { AppGlobalsService, JsonStoreService } from '../shared/services';
 
 @Component({
   selector: 'object-field',
@@ -40,14 +40,13 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
 
   @Input() value: Map<string, any>;
   @Input() schema: Object;
-  @Input() path: string;
+  @Input() path: Array<any>;
 
   keys: Array<string>;
 
-  @Output() onValueChange: EventEmitter<Map<string, any>> = new EventEmitter<any>();
-
-  constructor(public appGlobalsService: AppGlobalsService) {
-    super();
+  constructor(public appGlobalsService: AppGlobalsService,
+    public jsonStoreService: JsonStoreService) {
+    super(appGlobalsService);
   }
 
   ngOnInit() {
@@ -56,18 +55,16 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
     this.keys = this.value.keySeq().toArray();
   }
 
-  onPropertyChange(propertyValue: any, key: string) {
-    this.value = this.value.set(key, propertyValue);
-    this.onValueChange.emit(this.value);
-  }
-
   deleteField(name: string) {
+    // remove it from the record
     this.value = this.value.remove(name);
-    this.onValueChange.emit(this.value);
+    this.jsonStoreService.setIn(this.path, this.value);
+    // remove the key too, so that it will not be displayed as empty
+    this.keys.splice(this.keys.indexOf(name), 1);
   }
 
-  getFieldPath(name: string): string {
-    return `${this.path}.${name}`;
+  getFieldPath(name: string): Array<any> {
+    return this.path.concat(name);
   }
 
   onFieldAdd(field: string) {

--- a/src/primitive-field/primitive-field.component.html
+++ b/src/primitive-field/primitive-field.component.html
@@ -8,7 +8,7 @@
       <searchable-dropdown [value]="value" [items]="schema.enum" [shortcutMap]="schema.x_editor_enum_shortcut_map" (onSelect)="onModelChange($event)"></searchable-dropdown>
     </div>
     <div *ngSwitchCase="'autocomplete'">
-      <autocomplete-input [value]="value"  [autocompletionOptions]="schema.x_editor_autocomplete" (onValueChange)="onModelChange($event)" [placeholder]="schema.title"></autocomplete-input>
+      <autocomplete-input [value]="value" [path]="path" [autocompletionOptions]="schema.x_editor_autocomplete" (onValueChange)="onModelChange($event)" [placeholder]="schema.title"></autocomplete-input>
     </div>
     <div *ngSwitchCase="'integer'">
       <input type="number" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}">

--- a/src/primitive-field/primitive-field.component.html
+++ b/src/primitive-field/primitive-field.component.html
@@ -1,4 +1,4 @@
-<div [ngSwitch]="valueType" [id]="path">
+<div [ngSwitch]="valueType" [id]="path.join('.')">
   <div class="editable-field-container" [ngClass]="errorNgClass" [tooltipHtml]="errors | errorsToMessagesHtml" tooltipTrigger="mouseenter" [tooltipEnable]="isErrorTooltipEnabled">
     <div *ngSwitchCase="'string'">
       <textarea rows="1" textareaAutofit [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}"></textarea>

--- a/src/primitive-field/primitive-field.component.spec.ts
+++ b/src/primitive-field/primitive-field.component.spec.ts
@@ -37,7 +37,8 @@ import { ErrorsToMessagesHtmlPipe, FilterByExpressionPipe } from '../shared/pipe
 import {
   AppGlobalsService,
   ComponentTypeService,
-  SchemaValidationService
+  SchemaValidationService,
+  JsonStoreService
 } from '../shared/services';
 
 /**
@@ -54,6 +55,10 @@ import {
 function changeInputElementValue(el: HTMLInputElement, value: string) {
   el.value = value;
   el.dispatchEvent(new Event('input'));
+}
+
+class MockJsonStoreService extends JsonStoreService {
+  setIn(path: Array<any>, value: any) { }
 }
 
 describe('PrimitiveFieldComponent', () => {
@@ -78,7 +83,8 @@ describe('PrimitiveFieldComponent', () => {
       providers: [
         AppGlobalsService,
         ComponentTypeService,
-        SchemaValidationService
+        SchemaValidationService,
+        { provide: JsonStoreService, useClass: MockJsonStoreService }
       ]
     }).compileComponents();
   }));
@@ -89,6 +95,7 @@ describe('PrimitiveFieldComponent', () => {
 
     // force component to render completely by setting @Input() manually 
     component.value = 'defaultStringValue';
+    component.path = ['default', 'path'];
     component.schema = {
       type: 'string'
     };
@@ -115,11 +122,11 @@ describe('PrimitiveFieldComponent', () => {
     expect(component.value).toEqual(inputValue);
   });
 
-  it('should propagate change event to the parent', () => {
-    spyOn(component.onValueChange, 'emit');
+  it('should call jsonStore to change', () => {
+    spyOn(component.jsonStoreService, 'setIn');
     let newValue = 'newValue';
     changeInputElementValue(inputEl, newValue);
     fixture.detectChanges();
-    expect(component.onValueChange.emit).toHaveBeenCalledWith(newValue);
+    expect(component.jsonStoreService.setIn).toHaveBeenCalledWith(component.path, newValue);
   });
 });

--- a/src/primitive-field/primitive-field.component.ts
+++ b/src/primitive-field/primitive-field.component.ts
@@ -23,9 +23,7 @@
 import {
   Component,
   Input,
-  Output,
   OnInit,
-  EventEmitter,
   ViewEncapsulation,
   ChangeDetectionStrategy
 } from '@angular/core';
@@ -35,6 +33,7 @@ import { AbstractFieldComponent } from '../abstract-field';
 import {
   AppGlobalsService,
   ComponentTypeService,
+  JsonStoreService,
   SchemaValidationService
 } from '../shared/services';
 
@@ -49,16 +48,16 @@ import {
 })
 export class PrimitiveFieldComponent extends AbstractFieldComponent implements OnInit {
 
-  @Input() value: string | number | boolean;
   @Input() schema: Object;
-  @Input() path: string;
+  @Input() path: Array<any>;
 
-  @Output() onValueChange = new EventEmitter<any>();
+  @Input() value: string | number | boolean;
 
-  constructor(private schemaValidationService: SchemaValidationService,
-    private componentTypeService: ComponentTypeService,
-    public appGlobalsService: AppGlobalsService) {
-    super();
+  constructor(public schemaValidationService: SchemaValidationService,
+    public componentTypeService: ComponentTypeService,
+    public appGlobalsService: AppGlobalsService,
+    public jsonStoreService: JsonStoreService) {
+    super(appGlobalsService);
   }
 
   get valueType(): string {
@@ -81,6 +80,6 @@ export class PrimitiveFieldComponent extends AbstractFieldComponent implements O
     }
     // TODO: should we make the change even if it is not validated
     this.value = value;
-    this.onValueChange.emit(value);
+    this.jsonStoreService.setIn(this.path, value);
   }
 }

--- a/src/primitive-list-field/primitive-list-field.component.html
+++ b/src/primitive-list-field/primitive-list-field.component.html
@@ -1,9 +1,9 @@
-<div [id]="path">
+<div [id]="path.join('.')">
   <div class="wide">
     <table class="table">
-      <tr *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
+      <tr *ngFor="let value of values; let i = index; trackBy:trackByFunction">
         <td>
-          <primitive-field [value]="values.get(i)" (onValueChange)="onValueChange($event, i)" [schema]="schema.items" [path]="getValuePath(i)"></primitive-field>
+          <primitive-field [schema]="schema.items" [path]="getValuePath(i)"></primitive-field>
         </td>
 
         <!-- UP/DOWN and DELETE buttons for each row -->

--- a/src/primitive-list-field/primitive-list-field.component.ts
+++ b/src/primitive-list-field/primitive-list-field.component.ts
@@ -20,13 +20,13 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 import { List } from 'immutable';
 
 import { AbstractListFieldComponent } from '../abstract-list-field';
 
-import { AppGlobalsService, EmptyValueService } from '../shared/services';
+import { AppGlobalsService, JsonStoreService } from '../shared/services';
 
 @Component({
   selector: 'primitive-list-field',
@@ -38,38 +38,20 @@ import { AppGlobalsService, EmptyValueService } from '../shared/services';
 })
 // FIXME: this doesn't have all stuff of AbstractListFieldComponent. Maybe, it shouldn't extend it.
 export class PrimitiveListFieldComponent extends AbstractListFieldComponent {
-
   @Input() values: List<any>;
   @Input() schema: Object;
-  @Input() path: string;
+  @Input() path: Array<any>;
 
-  @Output() onValuesChange: EventEmitter<List<any>> = new EventEmitter<any>();
-
-  constructor(public emptyValueService: EmptyValueService,
-    public appGlobalsService: AppGlobalsService) {
-    super();
-  }
-
-  /**
-   * Called when any element of is changed of the values is changed
-   * @override
-   * 
-   * It casts new value to appropriate type.
-   * 
-   * @param {any} event - new value
-   * @param {number} index - index of changed element in array
-   * 
-   */
-  onValueChange(event: any, index: number) {
-    this.values = this.values.set(index, event);
-    this.onValuesChange.emit(this.values);
+  constructor(public appGlobalsService: AppGlobalsService,
+    public jsonStoreService: JsonStoreService) {
+    super(appGlobalsService, jsonStoreService);
   }
 
   /**
    * Returns path of an element at index.
    * @override
    */
-  getValuePath(index: number): string {
-    return `${this.path}.${index}`;
+  getValuePath(index: number): Array<any> {
+    return this.path.concat(index);
   }
 }

--- a/src/ref-field/ref-field.component.html
+++ b/src/ref-field/ref-field.component.html
@@ -1,4 +1,4 @@
-<div [id]="path" [ngSwitch]="shouldDisplayWithTemplate" >
+<div [id]="path.join('.')" [ngSwitch]="shouldDisplayWithTemplate" >
   <div *ngSwitchCase="true">
     <button class="btn-preview-template" *ngIf="isLazy" (click)="onPreviewClick($event)">👁</button>
   </div>

--- a/src/ref-field/ref-field.component.html
+++ b/src/ref-field/ref-field.component.html
@@ -1,8 +1,8 @@
 <div [id]="path.join('.')" [ngSwitch]="shouldDisplayWithTemplate" >
   <div *ngSwitchCase="true">
-    <button class="btn-preview-template" *ngIf="isLazy" (click)="onPreviewClick($event)">👁</button>
+    <button class="btn-preview-template" *ngIf="isLazy && !isPreviewButtonHidden" (click)="onPreviewClick($event)">👁</button>
   </div>
   <div *ngSwitchDefault>
-    <a target="_blank" [href]="refValue">{{refValue}}</a>
+    <a target="_blank" [href]="value.get('$ref')">{{value.get('$ref')}}</a>
   </div>
 </div>

--- a/src/ref-field/ref-field.component.ts
+++ b/src/ref-field/ref-field.component.ts
@@ -20,8 +20,16 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, Input, OnInit, ViewContainerRef } from '@angular/core';
-import { Http } from '@angular/http';
+import {
+  Component,
+  Input,
+  ViewContainerRef,
+  ChangeDetectionStrategy,
+  OnChanges,
+  SimpleChanges,
+  ComponentRef
+} from '@angular/core';
+import { Http, Headers, RequestOptions } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
 import { DynamicTemplateLoaderService } from '../shared/services';
@@ -31,41 +39,103 @@ import { DynamicTemplateLoaderService } from '../shared/services';
   styleUrls: [
     './ref-field.component.scss'
   ],
-  templateUrl: './ref-field.component.html'
+  templateUrl: './ref-field.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class RefFieldComponent implements OnInit {
+export class RefFieldComponent implements OnChanges {
 
   @Input() schema: Object;
-  @Input() refValue: string;
+  @Input() value: Map<string, any>;
   @Input() path: string;
 
-  refData$: Observable<Object>;
+  // shorthand variables to each schema config properties
   isLazy: boolean;
   customTemplate: string;
+  requestOptions: RequestOptions;
+
+  refData$: Observable<Object>;
   shouldDisplayWithTemplate: boolean = false;
+  isPreviewButtonHidden: boolean = false;
+  dynamicTemplateComponentRef: ComponentRef<any>;
 
   constructor(private viewContainer: ViewContainerRef,
     private http: Http,
     private dynamicTemplateLoaderService: DynamicTemplateLoaderService) { }
 
-  ngOnInit() {
-    if (this.schema['x_editor_ref_config']) {
-      this.isLazy = this.schema['x_editor_ref_config']['lazy'];
-      this.customTemplate = this.schema['x_editor_ref_config']['template'];
-      this.shouldDisplayWithTemplate = Boolean(this.customTemplate && this.refValue);
-      if (this.shouldDisplayWithTemplate) {
-        this.refData$ = this.http
-          .get(this.refValue)
-          .map(res => res.json());
-        if (!this.isLazy) {
-          this.dynamicTemplateLoaderService.loadTemplate(this.customTemplate, this.refData$, this.viewContainer);
-        }
+  ngOnChanges(changes: SimpleChanges) {
+    let valueChange = changes['value'];
+    // ngOnInit but needs to run before loading dynamic template
+    if (valueChange && valueChange.isFirstChange()) {
+      let config = this.schema['x_editor_ref_config'];
+      if (config) {
+        this.isLazy = config['lazy'];
+        this.customTemplate = config['template'];
+        this.requestOptions = new RequestOptions({
+          headers: this.createHeadersWithConfig(config['headers'])
+        });
+      }
+    }
+
+    // load template if necessary
+    this.shouldDisplayWithTemplate = Boolean(this.customTemplate && this.value.get('$ref'));
+    if (valueChange && valueChange.currentValue !== valueChange.previousValue && this.shouldDisplayWithTemplate) {
+      this.loadTemplateWithRef(false);
+    }
+
+    // clear the dynamic template when new $ref is empty or undefined
+    if (!this.shouldDisplayWithTemplate && this.dynamicTemplateComponentRef) {
+      this.dynamicTemplateComponentRef.instance.context = undefined;
+    }
+  }
+
+  onPreviewClick() {
+    this.loadTemplateWithRef(true);
+    this.isPreviewButtonHidden = true;
+  }
+
+  /**
+   * Displays the template
+   * 
+   * if the template hasn't loaded, loads the template asyncw with current $ref in this.value
+   * then assigns the loaded to this.dynamicTemplateComponentRef
+   * 
+   * if the template has already loaded, refreshes its context value with the data that
+   * is fetched from current $ref in this.value
+   * 
+   * Note: if called by onPreviewClick, hides the preview button.
+   * 
+   * 
+   * @param {boolean} force - should be set to load the template when it is lazy.
+   */
+  private loadTemplateWithRef(force: boolean) {
+    let ref = this.value.get('$ref');
+    this.refData$ = this.http
+      .get(ref, this.requestOptions)
+      .map(res => res.json())
+      .catch(error => {
+        console.warn(error);
+        return Observable.of({ error });
+      });
+    if (!this.isLazy || force) {
+      if (!this.dynamicTemplateComponentRef) {
+        this.dynamicTemplateLoaderService.loadTemplate(this.customTemplate, this.refData$, this.viewContainer)
+          .then(componentRef => {
+            this.dynamicTemplateComponentRef = componentRef;
+          });
+      } else {
+        this.dynamicTemplateComponentRef.instance.context = this.refData$;
+      }
+    } else {
+      this.isPreviewButtonHidden = false;
+      if (this.dynamicTemplateComponentRef) {
+        this.dynamicTemplateComponentRef.instance.context = undefined;
       }
     }
   }
 
-  onPreviewClick(event: Event) {
-    this.dynamicTemplateLoaderService.loadTemplate(this.customTemplate, this.refData$, this.viewContainer);
-    (event.target as HTMLElement).remove();
+  private createHeadersWithConfig(configHeaders: Array<HttpHeader>): Headers {
+    let headers = new Headers();
+    configHeaders.forEach(header => headers.append(header.name, header.value));
+    return headers;
   }
 }

--- a/src/shared/services/component-type.service.ts
+++ b/src/shared/services/component-type.service.ts
@@ -48,6 +48,8 @@ export class ComponentTypeService {
       return 'autocomplete';
     } else if (schema['enum']) {
       return 'enum';
+    } else if (schema['x_editor_on_value_change']) {
+      return 'value-change-watcher';
     }
 
     let schemaType = schema['type'];

--- a/src/shared/services/dom-util.service.ts
+++ b/src/shared/services/dom-util.service.ts
@@ -28,7 +28,7 @@ export class DomUtilService {
   focusAndSelectFirstInputChildById(id: string) {
     let el = document.getElementById(id);
     if (el) {
-      let firstInput = el.querySelector('input, textarea') as HTMLInputElement;
+      let firstInput = el.querySelector('div.editable-field-container input, textarea') as HTMLInputElement;
       if (firstInput) {
         firstInput.focus();
         firstInput.select();

--- a/src/shared/services/index.ts
+++ b/src/shared/services/index.ts
@@ -4,6 +4,7 @@ import { ComponentTypeService } from './component-type.service';
 import { DomUtilService } from './dom-util.service';
 import { DynamicTemplateLoaderService } from './dynamic-template-loader.service';
 import { EmptyValueService } from './empty-value.service';
+import { JsonStoreService } from './json-store.service';
 import { JsonUtilService } from './json-util.service';
 import { RecordFixerService } from './record-fixer.service';
 import { SchemaFixerService } from './schema-fixer.service';
@@ -17,6 +18,7 @@ export {
   DomUtilService,
   DynamicTemplateLoaderService,
   EmptyValueService,
+  JsonStoreService,
   JsonUtilService,
   RecordFixerService,
   SchemaFixerService,
@@ -31,6 +33,7 @@ export const SHARED_SERVICES = [
   DomUtilService,
   DynamicTemplateLoaderService,
   EmptyValueService,
+  JsonStoreService,
   JsonUtilService,
   RecordFixerService,
   SchemaFixerService,

--- a/src/shared/services/json-store.service.ts
+++ b/src/shared/services/json-store.service.ts
@@ -4,7 +4,7 @@ import { ReplaySubject } from 'rxjs';
 
 
 @Injectable()
-export class JsonStoreService {
+export class JsonStoreService implements NestedStore {
 
   private json: Map<string, any>;
   private _jsonChange: ReplaySubject<Map<string, any>> = new ReplaySubject<any>(1);

--- a/src/shared/services/json-store.service.ts
+++ b/src/shared/services/json-store.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Map } from 'immutable';
+import { ReplaySubject } from 'rxjs';
+
+
+@Injectable()
+export class JsonStoreService {
+
+  private json: Map<string, any>;
+  private _jsonChange: ReplaySubject<Map<string, any>> = new ReplaySubject<any>(1);
+
+  setIn(path: Array<any>, value: any) {
+    this.json = this.json.setIn(path, value);
+    this._jsonChange.next(this.json);
+  }
+
+  getIn(path: Array<any>): any {
+    return this.json.getIn(path);
+  }
+
+  setJson(json: Map<string, any>) {
+    this.json = json;
+  }
+
+  get jsonChange(): ReplaySubject<Map<string, any>> {
+    return this._jsonChange;
+  }
+}

--- a/src/table-list-field/table-list-field.component.html
+++ b/src/table-list-field/table-list-field.component.html
@@ -1,36 +1,35 @@
-<div [id]="path">
-	<div>
-		<table class="table editable-inner-table">
-			<thead class="thead-inverse">
-				<tr>
-					<th *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
-						{{key | underscoreToSpace}}
-					</th>
+<div [id]="path.join('.')">
+  <div>
+    <table class="table editable-inner-table">
+      <thead class="thead-inverse">
+        <tr>
+          <th *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
+            {{key | underscoreToSpace}}
+          </th>
 
-					<th class="button-holder">
-						<add-field-dropdown *ngIf="values.size > 0" [fields]="keys" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.items.properties"></add-field-dropdown>
-					</th>
+          <th class="button-holder">
+            <add-field-dropdown *ngIf="values.size > 0" [fields]="keys" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.items.properties"></add-field-dropdown>
+          </th>
 
-				</tr>
-			</thead>
-			<tr *ngFor="let row of values; let i = index; trackBy:trackByFunction" [id]="path + '.' + i">
-				<!-- Element value -->
-				<td *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
-					<any-type-field [value]="row.get(key) | selfOrEmpty:schema.items.properties[key]" (onValueChange)="onValueChange($event, i, key)"
-						[schema]="schema.items.properties[key]" [path]="getValuePath(i, key)"></any-type-field>
-					<add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [key]="key" [schema]="schema.items.properties[key]"
-						[values]="row.get(key) | selfOrEmpty:schema.items.properties[key]" (onNewElementAdd)="onValueChange($event, i, key)"></add-new-element-button>
-				</td>
+        </tr>
+      </thead>
+      <tr *ngFor="let row of values; let i = index; trackBy:trackByFunction" [id]="path.join('.') + '.' + i">
+        <!-- Element value -->
+        <td *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
+          <any-type-field [value]="row.get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
+            [path]="getValuePath(i, key)"></any-type-field>
+          <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(i, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
+        </td>
 
-				<!-- UP/DOWN and DELETE buttons for each row -->
-				<td *ngIf="values.size > 0" class="button-holder">
-					<button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
-					<button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
-					<button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">▼</button>
-				</td>
-			</tr>
-			<tr>
-			</tr>
-		</table>
-	</div>
+        <!-- UP/DOWN and DELETE buttons for each row -->
+        <td *ngIf="values.size > 0" class="button-holder">
+          <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
+          <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
+          <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">▼</button>
+        </td>
+      </tr>
+      <tr>
+      </tr>
+    </table>
+  </div>
 </div>

--- a/src/table-list-field/table-list-field.component.ts
+++ b/src/table-list-field/table-list-field.component.ts
@@ -20,16 +20,13 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, EventEmitter, Input, Output, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
 import { List, Map } from 'immutable';
 
 import { AbstractListFieldComponent } from '../abstract-list-field';
 
-import {
-  AppGlobalsService,
-  EmptyValueService
-} from '../shared/services';
+import { AppGlobalsService, JsonStoreService } from '../shared/services';
 
 @Component({
   selector: 'table-list-field',
@@ -43,15 +40,13 @@ export class TableListFieldComponent extends AbstractListFieldComponent implemen
 
   @Input() values: List<Map<string, any>>;
   @Input() schema: Object;
-  @Input() path: string;
-
-  @Output() onValuesChange: EventEmitter<List<Map<string, any>>> = new EventEmitter<any>();
+  @Input() path: Array<any>;
 
   keys: Array<string>;
 
-  constructor(public emptyValueService: EmptyValueService,
-    public appGlobalsService: AppGlobalsService) {
-    super();
+  constructor(public appGlobalsService: AppGlobalsService,
+    public jsonStoreService: JsonStoreService) {
+    super(appGlobalsService, jsonStoreService);
   }
 
   ngOnInit() {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -21,16 +21,31 @@
 */
 
 // TODO: investigate if it is good to define shared models here
+
 interface AutocompletionResult {
   text: string;
   payload?: Object;
+}
+
+interface NestedStore {
+  getIn(path: Array<any>): any;
+  setIn(path: Array<any>, value: any);
+}
+
+interface OnValueChangeFunction {
+  (path: Array<any>, value: any, store: NestedStore);
 }
 
 interface AutocompletionOptions {
   source?: Array<string>;
   url?: string;
   path?: string;
+  onCompletionSelect?: OnCompletionSelectFunction;
   size: number;
+}
+
+interface OnCompletionSelectFunction {
+  (path: Array<any>, completion: AutocompletionResult, store: NestedStore);
 }
 
 interface EditorConfig {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -48,6 +48,11 @@ interface OnCompletionSelectFunction {
   (path: Array<any>, completion: AutocompletionResult, store: NestedStore);
 }
 
+interface HttpHeader {
+  name: string;
+  value: string;
+}
+
 interface EditorConfig {
   schemaOptions?: Object;
   previews?: Array<Object>;

--- a/src/value-change-watcher/index.ts
+++ b/src/value-change-watcher/index.ts
@@ -1,0 +1,1 @@
+export { ValueChangeWatcherComponent } from './value-change-watcher.component';

--- a/src/value-change-watcher/value-change-watcher.component.html
+++ b/src/value-change-watcher/value-change-watcher.component.html
@@ -1,0 +1,1 @@
+<any-type-field [value]="value" [schema]="schema" [path]="path"></any-type-field>

--- a/src/value-change-watcher/value-change-watcher.component.ts
+++ b/src/value-change-watcher/value-change-watcher.component.ts
@@ -1,0 +1,76 @@
+/*
+ * This file is part of ng2-json-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * ng2-json-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * ng2-json-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ng2-json-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+import {
+  Component,
+  Input,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef
+} from '@angular/core';
+
+import { JsonStoreService } from '../shared/services';
+
+/**
+ * This component has dummy html but a logic to change the value of another part
+ * in top level json when its value changed. It's inserted in component tree
+ * just before the actual field, so that it can detect its change and
+ * run the call-back function
+ */
+@Component({
+  selector: 'value-change-watcher',
+  encapsulation: ViewEncapsulation.None,
+  templateUrl: './value-change-watcher.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ValueChangeWatcherComponent implements OnInit, OnChanges {
+
+  @Input() schema: Object;
+  @Input() path: Array<any>;
+  @Input() value: any;
+
+  onValueChange: OnValueChangeFunction;
+
+  constructor(public changeDetectionRef: ChangeDetectorRef,
+    public jsonStoreService: JsonStoreService) { }
+
+  ngOnInit() {
+    this.onValueChange = this.schema['x_editor_on_value_change'];
+    // remove this config so that it will not be detected as value-change-watcher again
+    // by ComponentTypeService, but its actual type
+    this.schema = Object.assign({}, this.schema);
+    delete this.schema['x_editor_on_value_change'];
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    let valueChange = changes['value'];
+    if (valueChange && !valueChange.isFirstChange()) {
+      // this.path.slice is used to pass by value not by reference, because the function might modify the path
+      this.onValueChange(this.path.slice(), valueChange.currentValue, this.jsonStoreService);
+      // force to detect changes since onValueChange might change some other parts of top level json
+      this.changeDetectionRef.detectChanges();
+    }
+  }
+}


### PR DESCRIPTION
#### add global store for top level json input
* Adds json-store service to read from/write to top level json input
via path which removes the @Output and event emitting structure and
make it possible to be read/written any part of json by any component.

* Fixes tree-menu focus first input element issue caused by filter
input in add-field-dropdown.

* Fixes #75

#### add on value change and completion select config
* Adds `x_editor_on_value_change` config that takes a function
with params like value, path, store (JsonStoreService/NestedStore) to be
executed when configured field is changed. It can do any manipulation
on top level json input.

* Adds NestedStore type to be able use, JsonStoreService type in
typings because importing something into typings.d.ts breaks it.

* Adds `onCompletionSelect` to `x_editor_autcomplete` that is executed
when a completion from dropdown is selected and it can access all
record via store (JsonStoreService/NestedStore).

* Avoids calling the remote autocompletion service when the input is
empty.

* Updates README accordingly.

* Fixes autocomplete-input component test

#### optimize ref field and add headers option
* Optimizes ref-field dynamic template loader by changing the context
of dynamic template instead of create a new one everytime.

* Adds headers option to ref config.

* Fixes minor bugs in ref-field.
