### PR TITLE
remove pdf.js in favor of iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Configuration for previews to be displayed in previewer (on the right side).
 [
   {
     name: string; (name of the tab which preview is displayed)
-    type: string; (type of the preview, such as "pdf")
+    type: string; (type of the preview, such as "html")
     url?: string; (preview url)
     getUrl?: function(record: Object): string; (function that takes record and returns preview url) 
     urlPath?: string; (dot separated path to preview url in the record)
@@ -214,12 +214,12 @@ Types:
 
 ```
 html
-pdf
 ```
 
 Note that:
 
 - Either `url`, `getUrl`, or `urlPath` must be present.
+- `html` type uses `iframe` and can display `.pdf` if supported by browser.
 
 ### $ref fields
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "core-js": "^2.4.1",
     "immutable": "^3.8.1",
     "ng2-bootstrap": "~1.1.5",
-    "ng2-pdf-viewer": "0.0.12",
     "rxjs": "5.0.0-beta.12",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.6.23"

--- a/src/editor-previewer/editor-previewer.component.html
+++ b/src/editor-previewer/editor-previewer.component.html
@@ -3,14 +3,8 @@
   <tabset [hidden]="hidden">
     <tab *ngFor="let preview of previews trackBy:trackByFunction" [heading]="preview.name">
       <div [ngSwitch]="preview.type">
-        <div *ngSwitchCase="'pdf'" class="preview-container">
-          <pdf-viewer [src]="preview.url" [show-all]="true" [original-size]="true" style="display: block;"></pdf-viewer>
-        </div>
         <div *ngSwitchCase="'html'" class="preview-container">
           <html-view [url]="preview.url"></html-view>
-        </div>
-        <div *ngSwitchDefault>
-          ##Unrecognized preview type: {{preview.type}}
         </div>
       </div>
     </tab>

--- a/src/json-editor.module.ts
+++ b/src/json-editor.module.ts
@@ -24,7 +24,6 @@ import { NgModule } from '@angular/core';
 
 // TODO: investigate if all modules or only used ones are in the bundle of the example app.
 import { Ng2BootstrapModule } from 'ng2-bootstrap/ng2-bootstrap';
-import { PdfViewerComponent } from 'ng2-pdf-viewer';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
@@ -53,7 +52,6 @@ import { SHARED_PIPES, SHARED_SERVICES, SHARED_DIRECTIVES } from './shared';
 
 @NgModule({
   declarations: [
-    PdfViewerComponent,
     ...SHARED_PIPES,
     ...SHARED_DIRECTIVES,
     AddFieldDropdownComponent,


### PR DESCRIPTION
* Removes pdf.js and pdf type for pdf previews in favor of iframe
since all major browsers' pdf viewers are better and faster at
rendering the pdf. (Fixes #50, Fixes #59)