### PR TITLE
Implement long list navigator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ Note that:
 
 - JsonStoreService's `getIn` and `setIn` returns and takes `immutable.js`'s `List` and `Map` instead of `Array` and `Object`
 
+#### x_editor_long_list_navigator
+
+```
+{
+  findSingle?: function(item: any, expression: string): boolean;
+    (the first item for which function returns true is set as search result)
+  findMultiple?: function(item: any, expression: string): boolean;
+    (all items for which function returns true is set as search results)
+  itemsPerPage: number; (number of items are displayed per page)
+  maxVisiblePageCount: number; (number of pages that are displayed in pagination view)
+}
+```
+
+Note that:
+
+- If both `findSingle` and `findMultiple` are defined in configuration, at first `findSingle` is executed for all items,
+if there is no result found then `findMultiple` is executed.
+
 ### <a name="previews"></a>Previews
 
 Configuration for previews to be displayed in previewer (on the right side).

--- a/example/app/app.config.ts
+++ b/example/app/app.config.ts
@@ -6,6 +6,19 @@ export const EXAMPLE_CONFIG: AppConfig = {
   schemaOptions: {
     'titles.items.properties.title': {
       x_editor_hidden: true
+    },
+    'references': {
+      x_editor_long_list_navigator: {
+        findSingle: (value, expression) => {
+          return value.getIn(['reference', 'number']) === parseInt(expression, 10);
+        },
+        findMultiple: (value, expression) => {
+          return JSON.stringify(value).search(expression) > -1;
+        },
+        itemsPerPage: 5,
+        maxVisiblePageCount: 5
+      }
     }
   }
+
 };

--- a/src/add-new-element-button/add-new-element-button.component.ts
+++ b/src/add-new-element-button/add-new-element-button.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 import { List } from 'immutable';
 
-import { EmptyValueService, JsonStoreService } from '../shared/services';
+import { DomUtilService, EmptyValueService, JsonStoreService } from '../shared/services';
 
 @Component({
   selector: 'add-new-element-button',
@@ -17,7 +17,8 @@ export class AddNewElementButtonComponent {
   @Input() path: Array<any>;
   @Input() schema: Object;
 
-  constructor(public emptyValueService: EmptyValueService,
+  constructor(public domUtilService: DomUtilService,
+    public emptyValueService: EmptyValueService,
     public jsonStoreService: JsonStoreService) { }
 
   get tooltipName(): string {
@@ -27,8 +28,15 @@ export class AddNewElementButtonComponent {
   addNewElement() {
     let itemSchema = this.schema['items'];
     let emptyValue = this.emptyValueService.generateEmptyValue(itemSchema);
-    let values = this.jsonStoreService.getIn(this.path) || List.of([]);
+    let values: List<any> = this.jsonStoreService.getIn(this.path) || List();
     this.jsonStoreService.setIn(this.path, values.push(emptyValue));
+    // focus on the new added element
+    let newElementPath = this.path
+      .concat(values.size)
+      .join('.');
+    setTimeout(() =>
+      this.domUtilService.focusAndSelectFirstInputChildById(newElementPath)
+    );
   }
 
 }

--- a/src/autocomplete-input/autocomplete-input.component.html
+++ b/src/autocomplete-input/autocomplete-input.component.html
@@ -1,4 +1,4 @@
 <div>
-  <input [ngModel]="value" (ngModelChange)="onModelChange($event)" [typeahead]="dataSource" [typeaheadOptionsLimit]="autocompletionOptions.size"
+  <input [ngModel]="value" (ngModelChange)="onModelChange($event)" (keypress)="onKeypress.emit($event)" (blur)="onBlur.emit()" [typeahead]="dataSource" [typeaheadOptionsLimit]="autocompletionOptions.size"
     [typeaheadOptionField]="typeaheadOptionField" (typeaheadOnSelect)="onCompletionSelect($event.item)" [typeaheadWaitMs]="200" placeholder="{{placeholder}}">
 </div>

--- a/src/autocomplete-input/autocomplete-input.component.ts
+++ b/src/autocomplete-input/autocomplete-input.component.ts
@@ -43,6 +43,8 @@ export class AutocompleteInputComponent implements OnInit {
   @Input() placeholder: string;
 
   @Output() onValueChange: EventEmitter<string> = new EventEmitter<any>();
+  @Output() onKeypress: EventEmitter<KeyboardEvent> = new EventEmitter<any>();
+  @Output() onBlur: EventEmitter<any> = new EventEmitter<any>();
 
   dataSource: Observable<string> | Array<string>;
   typeaheadOptionField: string;

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -1,17 +1,54 @@
 <div [id]="path.join('.')">
-  <div *ngFor="let value of values; let i = index; trackBy:trackByFunction" [id]="path.join('.') + '.' + i">
+  <!-- Navigator -->
+  <table *ngIf="navigator" class="navigator-container">
+    <tr>
+      <td class="form-group navigator-item-left">
+        <div class="input-group input-group-sm">
+          <span class="input-group-btn">
+            <button type="button" class="btn btn-default" (click)="onFindClick()">⚲</button>
+          </span>
+          <input type="search" class="form-control" [(ngModel)]="findExpression" (keypress)="onFindInputKeypress($event.key)" placeholder="Find"
+          />
+          <span class="input-group-btn" *ngIf="shouldDisplayFoundNavigation">
+            <button type="button" class="btn btn-default" [disabled]="currentFound <= 0" (click)="onFoundNavigate(-1)">❮</button>
+          </span>
+          <span class="input-group-btn" *ngIf="shouldDisplayFoundNavigation">
+            <button type="button" class="btn btn-default" [disabled]="currentFound >= foundIndices.length - 1" (click)="onFoundNavigate(1)">❯</button>
+          </span>
+          <span *ngIf="foundIndices" [ngSwitch]="foundIndices.length" class="input-group-addon transparent borderless">
+            <span *ngSwitchCase="0">
+              Nothing found
+            </span>
+          <span *ngSwitchDefault>
+              {{currentFound + 1}} of {{foundIndices.length}}
+            </span>
+          </span>
+        </div>
+      </td>
+      <td class="navigator-item-right">
+        <label>
+          {{paginatedIndices[0] + 1}}-{{paginatedIndices[paginatedIndices.length - 1] + 1}} of {{values.size}} {{path[path.length - 1]}}
+        </label>
+        <br>
+        <pagination [totalItems]="values.size" [ngModel]="currentPage" [maxSize]="navigator.maxVisiblePageCount" [itemsPerPage]="navigator.itemsPerPage"
+          class="pagination-sm pagination-top" [boundaryLinks]="true" [rotate]="false" [firstText]="'❮❮'" [previousText]="'❮'" [nextText]="'❯'"
+          [lastText]="'❯❯'" (pageChanged)="onPageChange($event.page)"></pagination>
+      </td>
+    </tr>
+  </table>
+  <div *ngFor="let pIndex of paginatedIndices; let i = index; trackBy:trackByFunction">
     <div class="complex-list-field-wrapper">
-      <table class="table">
+      <table class="table" [id]="path.join('.') + '.' + pIndex">
         <tr *ngFor="let key of keys[i] | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
           <td class="label-holder">
             <div>
               <label>{{key | underscoreToSpace}}</label>
-              <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(i, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
+              <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(pIndex, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
             </div>
           </td>
           <td>
-            <any-type-field [value]="value.get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
-              [path]="getValuePath(i, key)"></any-type-field>
+            <any-type-field [value]="values.get(pIndex).get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
+              [path]="getValuePath(pIndex, key)"></any-type-field>
           </td>
         </tr>
         <!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
@@ -20,9 +57,9 @@
             <add-field-dropdown [fields]="keys[i]" (onFieldAdd)="onFieldAdd($event, i)" [schema]="schema.items.properties"></add-field-dropdown>
           </td>
           <td class="button-holder button-holder-complex-list-actions">
-            <button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(i)">&times;</button>
-            <button *ngIf="i > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(i, -1)">▲</button>
-            <button *ngIf="i < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(i, 1)">▼</button>
+            <button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(pIndex)">&times;</button>
+            <button *ngIf="pIndex > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(pIndex, -1)">▲</button>
+            <button *ngIf="pIndex < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(pIndex, 1)">▼</button>
           </td>
         </tr>
       </table>

--- a/src/complex-list-field/complex-list-field.component.scss
+++ b/src/complex-list-field/complex-list-field.component.scss
@@ -1,9 +1,36 @@
 .complex-list-field-wrapper {
-    margin: 5px 15px 15px 15px;
-    padding: 5px;
-    box-shadow: 0 0 3px 1px rgba(0,0,0,0.25);
+  margin: 5px 15px 15px 15px;
+  padding: 5px;
+  box-shadow: 0 0 3px 1px rgba(0,0,0,0.25);
 }
 
 .button-holder-complex-list-actions {
-    text-align: right;
+  text-align: right;
+}
+
+.navigator-container {
+  width: 100%;  
+}
+
+$navigator-item-padding: 13px;
+
+.navigator-item-right {
+  float: right;
+  padding-right: $navigator-item-padding !important;
+  label {
+    position: relative;
+    top: -19px;
+  }
+}
+
+.navigator-item-left {
+  padding-left: $navigator-item-padding !important;
+}
+
+.transparent {
+  background: transparent;
+}
+
+.borderless {
+  border: none;
 }

--- a/src/editor-previewer/index.ts
+++ b/src/editor-previewer/index.ts
@@ -1,1 +1,1 @@
-export { EditorPreviewerComponent, Preview } from './editor-previewer.component';
+export { EditorPreviewerComponent } from './editor-previewer.component';

--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -126,6 +126,10 @@ table {
   } 
 }
 
+ul.pagination-top {
+  margin: -16px 0px 0px 0px;
+}
+
 td.button-holder, th.button-holder {
   width: 65px;
 }

--- a/src/json-editor.component.ts
+++ b/src/json-editor.component.ts
@@ -91,7 +91,8 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
     this.jsonStoreService.setJson(this._record);
     // listen for all changes on json
     this.jsonStoreService.jsonChange
-      .subscribe((json) => {
+      .skipWhile(json => json === this._record)
+      .subscribe(json => {
         this._record = json;
         // emit the change as plain JS object
         this.onRecordChange.emit(json.toJS());

--- a/src/primitive-field/primitive-field.component.html
+++ b/src/primitive-field/primitive-field.component.html
@@ -1,20 +1,22 @@
 <div [ngSwitch]="valueType" [id]="path.join('.')">
-  <div class="editable-field-container" [ngClass]="errorNgClass" [tooltipHtml]="errors | errorsToMessagesHtml" tooltipTrigger="mouseenter" [tooltipEnable]="isErrorTooltipEnabled">
+  <div class="editable-field-container" [ngClass]="errorNgClass" [tooltipHtml]="errors | errorsToMessagesHtml" tooltipTrigger="mouseenter"
+    [tooltipEnable]="isErrorTooltipEnabled">
     <div *ngSwitchCase="'string'">
-      <textarea rows="1" textareaAutofit [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}"></textarea>
+      <textarea rows="1" textareaAutofit [(ngModel)]="value" (blur)="commitValueChange()" (keypress)="onKeypress($event)" placeholder="{{schema.title}}"></textarea>
     </div>
     <div *ngSwitchCase="'enum'">
       <!-- TODO: set placeholder -->
-      <searchable-dropdown [value]="value" [items]="schema.enum" [shortcutMap]="schema.x_editor_enum_shortcut_map" (onSelect)="onModelChange($event)"></searchable-dropdown>
+      <searchable-dropdown [value]="value" [items]="schema.enum" [shortcutMap]="schema.x_editor_enum_shortcut_map" (onSelect)="onSearchableDropdownSelect($event)"></searchable-dropdown>
     </div>
     <div *ngSwitchCase="'autocomplete'">
-      <autocomplete-input [value]="value" [path]="path" [autocompletionOptions]="schema.x_editor_autocomplete" (onValueChange)="onModelChange($event)" [placeholder]="schema.title"></autocomplete-input>
+      <autocomplete-input [value]="value" [path]="path" [autocompletionOptions]="schema.x_editor_autocomplete" (onBlur)="commitValueChange()"
+        (onKeypress)="onKeypress($event)" (onValueChange)="onAutcompleteInputValueChange($event)" [placeholder]="schema.title"></autocomplete-input>
     </div>
     <div *ngSwitchCase="'integer'">
-      <input type="number" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}">
+      <input type="number" [(ngModel)]="value" (blur)="commitValueChange()" (keypress)="onKeypress($event)" placeholder="{{schema.title}}">
     </div>
     <div *ngSwitchCase="'boolean'">
-      <input type="checkbox" [ngModel]="value" (ngModelChange)="onModelChange($event)" placeholder="{{schema.title}}">
+      <input type="checkbox" [(ngModel)]="value" (ngModelChange)="commitValueChange()" placeholder="{{schema.title}}">
     </div>
     <div *ngSwitchDefault>
       ## Not recognized type: {{valueType}}

--- a/src/primitive-field/primitive-field.component.spec.ts
+++ b/src/primitive-field/primitive-field.component.spec.ts
@@ -122,11 +122,29 @@ describe('PrimitiveFieldComponent', () => {
     expect(component.value).toEqual(inputValue);
   });
 
-  it('should call jsonStore to change', () => {
+  it('should call jsonStore for change on blur', () => {
     spyOn(component.jsonStoreService, 'setIn');
+    // change the value
     let newValue = 'newValue';
     changeInputElementValue(inputEl, newValue);
     fixture.detectChanges();
+    // blur
+    inputEl.dispatchEvent(new Event('blur'));
+
+    expect(component.jsonStoreService.setIn).toHaveBeenCalledWith(component.path, newValue);
+  });
+
+  it('should call jsonStore for change on enter pressed', () => {
+    spyOn(component.jsonStoreService, 'setIn');
+    // change the value
+    let newValue = 'newValue';
+    changeInputElementValue(inputEl, newValue);
+    fixture.detectChanges();
+    // press enter
+    let enterPressedEvent = new Event('keypress');
+    enterPressedEvent['key'] = 'Enter';
+    inputEl.dispatchEvent(enterPressedEvent);
+
     expect(component.jsonStoreService.setIn).toHaveBeenCalledWith(component.path, newValue);
   });
 });

--- a/src/primitive-field/primitive-field.component.ts
+++ b/src/primitive-field/primitive-field.component.ts
@@ -69,17 +69,33 @@ export class PrimitiveFieldComponent extends AbstractFieldComponent implements O
     this.schema = this.schema || {};
   }
 
-  onModelChange(value: any) {
+  commitValueChange() {
     // Validation
     if (this.schema['type'] === 'string' && this.schema['enum'] === undefined) {
       try {
-        this.schemaValidationService.validateStringValue(value.toString(), this.schema);
+        this.schemaValidationService.validateStringValue(this.value.toString(), this.schema);
       } catch (error) {
         console.error(error);
       }
     }
     // TODO: should we make the change even if it is not validated
-    this.value = value;
-    this.jsonStoreService.setIn(this.path, value);
+    this.jsonStoreService.setIn(this.path, this.value);
   }
+
+  onKeypress(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      this.commitValueChange();
+      event.preventDefault();
+    }
+  }
+
+  onAutcompleteInputValueChange(value: string) {
+    this.value = value;
+  }
+
+  onSearchableDropdownSelect(value: string) {
+    this.value = value;
+    this.commitValueChange();
+  }
+
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -57,6 +57,17 @@ interface GetUrlFunction {
   (record: Object): string;
 }
 
+interface LongListNavigatorConfig {
+  findSingle?: FindItemFunction;
+  findMultiple?: FindItemFunction;
+  itemsPerPage: number;
+  maxVisiblePageCount: number;
+}
+
+interface FindItemFunction {
+  (item: any, expression: string): boolean;
+}
+
 interface Preview {
   name: string;
   type: string;


### PR DESCRIPTION
* Changes the primitive field to apply the changes to
global store on enter pressed and on input blur.

* Updates tests of primitive-field for blur/press-enter
store update.

* Adds x_editor_long_list_navigator config option.

* Adds navigator when long_list navigator is enabled for
a complext list. Navigator has find functionality and a paginator.

* Removes tsc error for Preview.

TODOS:

* Remove changes in example/*

* Clean the complex list code if possible, might need to  move
some code to a service.