### PR TITLE
add configurable link button to primitive-field

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ Note that:
 - If both `findSingle` and `findMultiple` are defined in configuration, at first `findSingle` is executed for all items,
 if there is no result found then `findMultiple` is executed.
 
+#### x_editor_link_builder
+
+The function that returns a url string which will be pointed by a small link button at the right side of input element.
+
+```
+function(value: any): string;
+```
+
 ### <a name="previews"></a>Previews
 
 Configuration for previews to be displayed in previewer (on the right side).

--- a/example/app/app.config.ts
+++ b/example/app/app.config.ts
@@ -18,6 +18,11 @@ export const EXAMPLE_CONFIG: AppConfig = {
         itemsPerPage: 5,
         maxVisiblePageCount: 5
       }
+    },
+    'arxiv_eprints.items.properties.value': {
+      x_editor_link_builder: (value: any) => {
+        return `http://arxiv.org/abs/${value}`;
+      }
     }
   }
 

--- a/src/primitive-field/primitive-field.component.html
+++ b/src/primitive-field/primitive-field.component.html
@@ -1,30 +1,39 @@
 <div [ngSwitch]="valueType" [id]="path.join('.')">
-  <div class="editable-field-container" [ngClass]="errorNgClass" [tooltipHtml]="errors | errorsToMessagesHtml" tooltipTrigger="mouseenter"
-    [tooltipEnable]="isErrorTooltipEnabled">
-    <div *ngSwitchCase="'string'">
-      <textarea rows="1" textareaAutofit [(ngModel)]="value" (blur)="commitValueChange()" (keypress)="onKeypress($event)" placeholder="{{schema.title}}"></textarea>
-    </div>
-    <div *ngSwitchCase="'enum'">
-      <!-- TODO: set placeholder -->
-      <searchable-dropdown [value]="value" [items]="schema.enum" [shortcutMap]="schema.x_editor_enum_shortcut_map" (onSelect)="onSearchableDropdownSelect($event)"></searchable-dropdown>
-    </div>
-    <div *ngSwitchCase="'autocomplete'">
-      <autocomplete-input [value]="value" [path]="path" [autocompletionOptions]="schema.x_editor_autocomplete" (onBlur)="commitValueChange()"
-        (onKeypress)="onKeypress($event)" (onValueChange)="onAutcompleteInputValueChange($event)" [placeholder]="schema.title"></autocomplete-input>
-    </div>
-    <div *ngSwitchCase="'integer'">
-      <input type="number" [(ngModel)]="value" (blur)="commitValueChange()" (keypress)="onKeypress($event)" placeholder="{{schema.title}}">
-    </div>
-    <div *ngSwitchCase="'boolean'">
-      <input type="checkbox" [(ngModel)]="value" (ngModelChange)="commitValueChange()" placeholder="{{schema.title}}">
-    </div>
-    <div *ngSwitchDefault>
-      ## Not recognized type: {{valueType}}
-    </div>
-  </div>
-  <div>
-    <div *ngSwitchCase="'disabled'">
-      {{value}}
-    </div>
-  </div>
+  <table class="input-container">
+    <tr>
+      <td class="value-holder">
+        <div class="editable-field-container" [ngClass]="errorNgClass" [tooltipHtml]="errors | errorsToMessagesHtml" tooltipTrigger="mouseenter"
+          [tooltipEnable]="isErrorTooltipEnabled">
+          <div *ngSwitchCase="'string'">
+            <textarea rows="1" textareaAutofit [(ngModel)]="value" (blur)="commitValueChange()" (keypress)="onKeypress($event)" placeholder="{{schema.title}}"></textarea>
+          </div>
+          <div *ngSwitchCase="'enum'">
+            <!-- TODO: set placeholder -->
+            <searchable-dropdown [value]="value" [items]="schema.enum" [shortcutMap]="schema.x_editor_enum_shortcut_map" (onSelect)="onSearchableDropdownSelect($event)"></searchable-dropdown>
+          </div>
+          <div *ngSwitchCase="'autocomplete'">
+            <autocomplete-input [value]="value" [path]="path" [autocompletionOptions]="schema.x_editor_autocomplete" (onBlur)="commitValueChange()"
+              (onKeypress)="onKeypress($event)" (onValueChange)="onAutocompleteInputValueChange($event)" [placeholder]="schema.title"></autocomplete-input>
+          </div>
+          <div *ngSwitchCase="'integer'">
+            <input type="number" [(ngModel)]="value" (blur)="commitValueChange()" (keypress)="onKeypress($event)" placeholder="{{schema.title}}">
+          </div>
+          <div *ngSwitchCase="'boolean'">
+            <input type="checkbox" [(ngModel)]="value" (ngModelChange)="commitValueChange()" placeholder="{{schema.title}}">
+          </div>
+          <div *ngSwitchDefault>
+            ## Not recognized type: {{valueType}}
+          </div>
+        </div>
+        <div>
+          <div *ngSwitchCase="'disabled'">
+            {{value}}
+          </div>
+        </div>
+      </td>
+      <td class="link-button-holder">
+        <a *ngIf="linkBuilder" class="no-decoration" target="_blank" [href]="linkBuilder(value)">🔗</a>
+      </td>
+    </tr>
+  </table>
 </div>

--- a/src/primitive-field/primitive-field.component.scss
+++ b/src/primitive-field/primitive-field.component.scss
@@ -1,21 +1,40 @@
 div.editable-field-container textarea,
 div.editable-field-container input {
-    vertical-align: middle;
-    width: 50%;
-    padding: 0 0 0 3px;
-    transition: all 0.5s ease;
-    resize: none;
-    border: none;
-    background-color: transparent;
-    display: inline-block;
-    
-    // Fill parent's width 
-    width:100%;
-    box-sizing: border-box;         // For IE and modern versions of Chrome
-    -moz-box-sizing: border-box;    // For Firefox   
-    -webkit-box-sizing: border-box; // For Safari
+  vertical-align: middle;
+  width: 50%;
+  padding: 0 0 0 3px;
+  transition: all 0.5s ease;
+  resize: none;
+  border: none;
+  background-color: transparent;
+  display: inline-block;
+
+  // Fill parent's width 
+  width:100%;
+  box-sizing: border-box;         // For IE and modern versions of Chrome
+  -moz-box-sizing: border-box;    // For Firefox   
+  -webkit-box-sizing: border-box; // For Safari
 }
 
 div.editable-field-container:hover {
-    background: #ffa;
+  background: #ffa;
+}
+
+table.input-container {
+  width: 100%;
+  td {
+    background: transparent !important;
+  }
+}
+
+td.link-button-holder {
+  width: 22px;
+}
+
+td.value-holder {
+  width: 100%;
+}
+
+a.no-decoration {
+  text-decoration: none;
 }

--- a/src/primitive-field/primitive-field.component.ts
+++ b/src/primitive-field/primitive-field.component.ts
@@ -34,7 +34,7 @@ import {
   AppGlobalsService,
   ComponentTypeService,
   JsonStoreService,
-  SchemaValidationService
+  SchemaValidationService,
 } from '../shared/services';
 
 @Component({
@@ -89,13 +89,17 @@ export class PrimitiveFieldComponent extends AbstractFieldComponent implements O
     }
   }
 
-  onAutcompleteInputValueChange(value: string) {
+  onAutocompleteInputValueChange(value: string) {
     this.value = value;
   }
 
   onSearchableDropdownSelect(value: string) {
     this.value = value;
     this.commitValueChange();
+  }
+
+  get linkBuilder(): LinkBuilderFunction {
+    return this.schema['x_editor_link_builder'];
   }
 
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -68,6 +68,10 @@ interface FindItemFunction {
   (item: any, expression: string): boolean;
 }
 
+interface LinkBuilderFunction {
+  (value: any): string;
+}
+
 interface Preview {
   name: string;
   type: string;


### PR DESCRIPTION
* Adds x_editor_link_builder function that takes a primitive value
and returns a url string which will be pointed by a small anchor element
next to the input element of primitive field. (Fixes #80)

* Adds example config for x_editor_link_builder.