### PR TITLE
purify pipes and use immutables in pipes

### DIFF
--- a/src/add-field-dropdown/add-field-dropdown.component.spec.ts
+++ b/src/add-field-dropdown/add-field-dropdown.component.spec.ts
@@ -22,6 +22,8 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { Set } from 'immutable';
+
 import { AddFieldDropdownComponent } from './add-field-dropdown.component';
 
 import { Ng2BootstrapModule } from 'ng2-bootstrap';
@@ -36,8 +38,8 @@ const schemaProperties = {
   propNotInValueA: {},
   propNotInValueB: {}
 };
-const fields = ['propA', 'propB'];
-const mockDifferentKeys = ['propNotInValueA', 'propNotInValueB'];
+const fields = Set(['propA', 'propB']);
+const mockDifferentKeys = Set(['propNotInValueB', 'propNotInValueA']);
 const emptyValue = 'empty-value';
 
 class MockEmptyValueService extends EmptyValueService {
@@ -83,16 +85,18 @@ describe('AddFieldToObjectDropdownComponent', () => {
 
   it('should show different keys of schema', () => {
     showDropdownButton.dispatchEvent(new Event('click'));
-    let items: Array<string> = Array.prototype
-      .slice.call(nativeEl.querySelectorAll('li a'))
-      .map((a: HTMLAnchorElement) => a.textContent);
+    let items: Set<string> = Set(
+      Array.prototype
+        .slice.call(nativeEl.querySelectorAll('li a'))
+        .map((a: HTMLAnchorElement) => a.textContent) as Array<string>
+    );
     expect(items).toEqual(mockDifferentKeys);
   });
 
   it('should add field with empty value when dropdown item clicked', () => {
     showDropdownButton.dispatchEvent(new Event('click'));
     let anchor = nativeEl.querySelector('li a') as HTMLAnchorElement;
-    expect(component.fields.indexOf(anchor.textContent)).toEqual(-1);
+    expect(component.fields.has(anchor.textContent)).toBeFalsy();
     spyOn(component.onFieldAdd, 'emit');
     anchor.dispatchEvent(new Event('click'));
     expect(component.onFieldAdd.emit).toHaveBeenCalledWith(anchor.textContent);

--- a/src/add-field-dropdown/add-field-dropdown.component.ts
+++ b/src/add-field-dropdown/add-field-dropdown.component.ts
@@ -22,6 +22,8 @@
 
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
+import { Set } from 'immutable';
+
 import { DomUtilService, EmptyValueService } from '../shared/services';
 
 @Component({
@@ -35,7 +37,7 @@ export class AddFieldDropdownComponent {
 
   // 'propeties' of an object schema
   @Input() schema: Object;
-  @Input() fields: Array<string>;
+  @Input() fields: Set<string>;
   @Input() pathString: string;
 
   @Output() onFieldAdd: EventEmitter<string> = new EventEmitter<string>();
@@ -46,7 +48,7 @@ export class AddFieldDropdownComponent {
     private emptyValueService: EmptyValueService) { }
 
   get disabled(): boolean {
-    return Object.keys(this.schema).length === this.fields.length;
+    return Object.keys(this.schema).length === this.fields.size;
   }
 
   focusElementIfOpen(isDropdownOpen: boolean, el: HTMLElement) {

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -39,7 +39,7 @@
   <div *ngFor="let pIndex of paginatedIndices; let i = index; trackBy:trackByFunction">
     <div class="complex-list-field-wrapper">
       <table class="table" [id]="getElementPathString(pIndex)">
-        <tr *ngFor="let key of keys[i] | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
+        <tr *ngFor="let key of keys.get(i) | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction">
           <td class="label-holder">
             <div>
               <title-dropdown [title]="key | underscoreToSpace" [isDisabled]="schema.items.properties[key].x_editor_disabled">
@@ -60,7 +60,7 @@
         <!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
         <tr *ngIf="values.size > 0">
           <td class="button-holder">
-            <add-field-dropdown [fields]="keys[i]" [pathString]="getElementPathString(pIndex)" (onFieldAdd)="onFieldAdd(i, $event)" [schema]="schema.items.properties">+</add-field-dropdown>
+            <add-field-dropdown [fields]="keys.get(i)" [pathString]="getElementPathString(pIndex)" (onFieldAdd)="onFieldAdd(i, $event)" [schema]="schema.items.properties">+</add-field-dropdown>
           </td>
           <td class="button-holder button-holder-complex-list-actions">
             <button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(pIndex)">&times;</button>

--- a/src/complex-list-field/complex-list-field.component.ts
+++ b/src/complex-list-field/complex-list-field.component.ts
@@ -29,7 +29,7 @@ import {
   SimpleChanges
 } from '@angular/core';
 
-import { List, Map } from 'immutable';
+import { List, Map, Set } from 'immutable';
 
 import { AbstractListFieldComponent } from '../abstract-list-field';
 
@@ -50,7 +50,7 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   @Input() schema: Object;
   @Input() path: Array<any>;
 
-  keys: Array<Array<string>>;
+  keys: List<Set<string>>;
   paginatedIndices: Array<number>;
 
   foundIndices: Array<number>;
@@ -103,7 +103,8 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   }
 
   onFieldAdd(index: number, field: string) {
-    this.keys[index].push(field);
+    this.keys = this.keys
+      .update(index, value => value.add(field));
     setTimeout(() => {
       this.tabIndexService.sortAndSynchronizeTabIndexes();
     });
@@ -114,7 +115,8 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
     this.jsonStoreService.setIn(this.path, this.values);
 
     // remove it from keys too, so that it will not be displayed as empty
-    this.keys[index].splice(this.keys.indexOf(name), 1);
+    this.keys = this.keys
+      .update(index, value => value.remove(field));
   }
 
   onFindClick() {
@@ -188,9 +190,11 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
     return indices;
   }
 
-  getKeysForCurrentPage(): Array<Array<string>> {
-    return this.paginatedIndices
-      .map(pIndex => this.values.get(pIndex).keySeq().toArray());
+  getKeysForCurrentPage(): List<Set<string>> {
+    return List(
+      this.paginatedIndices
+        .map(pIndex => this.values.get(pIndex).keySeq().toSet())
+    );
   }
 
   getPageForIndex(index: number): number {

--- a/src/json-editor.component.ts
+++ b/src/json-editor.component.ts
@@ -31,7 +31,7 @@ import {
 } from '@angular/core';
 import { Http } from '@angular/http';
 
-import { fromJS, Map } from 'immutable';
+import { fromJS, Map, Set } from 'immutable';
 
 import { AbstractTrackerComponent } from './abstract-tracker';
 
@@ -67,7 +67,7 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
 
   _record: Map<string, any>;
   previews: Array<any> = [];
-  keys: Array<string>;
+  keys: Set<string>;
 
   constructor(public http: Http,
     public appGlobalsService: AppGlobalsService,
@@ -98,7 +98,7 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
     // set errors that is used by other components
     this.appGlobalsService.globalErrors = this.errorMap;
     // get names of top-level fields
-    this.keys = Object.keys(this.record);
+    this.keys = Set.fromKeys(this.record);
     // use fromJS to convert input to immutable then pass it to the store
     this._record = fromJS(this.record);
     this.jsonStoreService.setJson(this._record);
@@ -140,7 +140,7 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
     this._record = this._record.remove(field);
     this.jsonStoreService.setJson(this._record);
 
-    this.keys.splice(this.keys.indexOf(field), 1);
+    this.keys = this.keys.remove(field);
   }
 
   getPathForField(field: string): Array<any> {
@@ -148,7 +148,7 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
   }
 
   onFieldAdd(field: string) {
-    this.keys.push(field);
+    this.keys = this.keys.add(field);
   }
 
   get shortcuts() {

--- a/src/object-field/object-field.component.ts
+++ b/src/object-field/object-field.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
-import { Map } from 'immutable';
+import { Map, Set } from 'immutable';
 
 import { AbstractFieldComponent } from '../abstract-field';
 
@@ -42,7 +42,7 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
   @Input() schema: Object;
   @Input() path: Array<any>;
 
-  keys: Array<string>;
+  keys: Set<string>;
 
   constructor(public appGlobalsService: AppGlobalsService,
     public jsonStoreService: JsonStoreService) {
@@ -52,7 +52,7 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
   ngOnInit() {
     super.ngOnInit();
 
-    this.keys = this.value.keySeq().toArray();
+    this.keys = this.value.keySeq().toSet();
   }
 
   deleteField(name: string) {
@@ -60,7 +60,7 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
     this.value = this.value.remove(name);
     this.jsonStoreService.setIn(this.path, this.value);
     // remove the key too, so that it will not be displayed as empty
-    this.keys.splice(this.keys.indexOf(name), 1);
+    this.keys = this.keys.remove(name);
   }
 
   getFieldPath(name: string): Array<any> {
@@ -68,7 +68,7 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
   }
 
   onFieldAdd(field: string) {
-    this.keys.push(field);
+    this.keys = this.keys.add(field);
   }
 
 }

--- a/src/shared/pipes/add-always-show-fields.pipe.ts
+++ b/src/shared/pipes/add-always-show-fields.pipe.ts
@@ -22,21 +22,17 @@
 
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { EmptyValueService } from '../services';
+import { Set } from 'immutable';
 
 @Pipe({
-  name: 'addAlwaysShowFields',
-  pure: false
+  name: 'addAlwaysShowFields'
 })
 export class AddAlwaysShowFieldsPipe implements PipeTransform {
 
-  constructor(public emptyValueService: EmptyValueService) { }
-
-  transform(fields: Array<string>, schema: Object): Object {
-    let fieldsSet = new Set(fields);
+  transform(fields: Set<string>, schema: Object): Set<string> {
     let schemaProps = schema['properties'];
-    let missingAlwayShowFields = Object.keys(schemaProps)
-      .filter(prop => schemaProps[prop]['x_editor_always_show'] && !fieldsSet.has(prop));
-    return fields.concat(missingAlwayShowFields);
+    let alwayShowFields = Object.keys(schemaProps)
+      .filter(prop => schemaProps[prop]['x_editor_always_show']);
+    return fields.union(alwayShowFields);
   }
 }

--- a/src/shared/pipes/different-keys.pipe.spec.ts
+++ b/src/shared/pipes/different-keys.pipe.spec.ts
@@ -22,6 +22,8 @@
 
 import { DifferentKeysPipe } from './different-keys.pipe';
 
+import { Set } from 'immutable';
+
 describe('DifferentKeysPipe', () => {
   let pipe: DifferentKeysPipe;
 
@@ -37,11 +39,11 @@ describe('DifferentKeysPipe', () => {
       propDiff2: 1
     };
 
-    let arr = ['propA', 'propB'];
+    let existingKeys = Set(['propA', 'propB']);
 
-    let differentKeys = ['propDiff1', 'propDiff2'];
+    let differentKeys = Set(['propDiff1', 'propDiff2']);
 
-    let pipeResult = pipe.transform(obj, arr);
+    let pipeResult = pipe.transform(obj, existingKeys);
     expect(pipeResult).toEqual(differentKeys);
   });
 
@@ -51,10 +53,10 @@ describe('DifferentKeysPipe', () => {
       propB: 1
     };
 
-    let arr = ['propA', 'propB'];
+    let existingKeys = Set(['propA', 'propB']);
 
-    let pipeResult = pipe.transform(obj, arr);
-    expect(pipeResult).toEqual([]);
+    let pipeResult = pipe.transform(obj, existingKeys);
+    expect(pipeResult).toEqual(Set());
   });
 
 });

--- a/src/shared/pipes/different-keys.pipe.ts
+++ b/src/shared/pipes/different-keys.pipe.ts
@@ -21,18 +21,16 @@
 */
 
 import { Pipe, PipeTransform } from '@angular/core';
+
+import { Set } from 'immutable';
 /**
- * It returns array of keys which aren't present in given object (other)
+ * It returns array of keys which aren't present in given object
  */
 @Pipe({
-  name: 'differentKeys',
-  pure: false
+  name: 'differentKeys'
 })
 export class DifferentKeysPipe implements PipeTransform {
-  transform(object: Object, keys: Array<string>): Array<string> {
-    let objectKeys = Object.keys(object);
-    let keysSet = new Set(keys);
-    return objectKeys
-      .filter( objectKey => !keysSet.has(objectKey));
+  transform(object: Object, keys: Set<string>): Set<string> {
+    return Set.fromKeys(object).subtract(keys);
   }
 }

--- a/src/shared/pipes/filter-and-sort-by-schema.pipe.spec.ts
+++ b/src/shared/pipes/filter-and-sort-by-schema.pipe.spec.ts
@@ -23,6 +23,8 @@
 import { FilterAndSortBySchemaPipe } from './filter-and-sort-by-schema.pipe';
 import { AppGlobalsService } from '../services';
 
+import { Set, OrderedSet } from 'immutable';
+
 describe('FilterAndSortBySchemaPipe', () => {
   let pipe: FilterAndSortBySchemaPipe;
 
@@ -41,9 +43,9 @@ describe('FilterAndSortBySchemaPipe', () => {
         }
       }
     };
-    let keys = ['key1', 'key2'];
+    let keys = Set(['key1', 'key2']);
 
-    let expected = ['key2', 'key1'];
+    let expected = OrderedSet(['key2', 'key1']);
 
     expect(pipe.transform(keys, schema)).toEqual(expected);
   });
@@ -55,9 +57,9 @@ describe('FilterAndSortBySchemaPipe', () => {
         key2: {}
       }
     };
-    let keys = ['key2', 'key1'];
+    let keys = Set(['key2', 'key1']);
 
-    let expected = ['key1', 'key2'];
+    let expected = OrderedSet(['key1', 'key2']);
 
     expect(pipe.transform(keys, schema)).toEqual(expected);
   });
@@ -76,9 +78,9 @@ describe('FilterAndSortBySchemaPipe', () => {
           key4: {}
         }
       };
-      let keys = ['key1', 'key2', 'key3', 'key4'];
+      let keys = Set(['key1', 'key2', 'key3', 'key4']);
 
-      let expected = ['key2', 'key1', 'key3', 'key4'];
+      let expected = OrderedSet(['key2', 'key1', 'key3', 'key4']);
 
       expect(pipe.transform(keys, schema)).toEqual(expected);
     });
@@ -100,9 +102,9 @@ describe('FilterAndSortBySchemaPipe', () => {
           key5: {}
         }
       };
-      let keys = ['key5', 'key1', 'key2', 'key4', 'key3'];
+      let keys = Set(['key5', 'key1', 'key2', 'key4', 'key3']);
 
-      let expected = ['key4', 'key3', 'key5', 'key2', 'key1'];
+      let expected = OrderedSet(['key4', 'key3', 'key5', 'key2', 'key1']);
 
       expect(pipe.transform(keys, schema)).toEqual(expected);
     });
@@ -117,9 +119,9 @@ describe('FilterAndSortBySchemaPipe', () => {
         }
       }
     };
-    let keys = ['key1', 'key2'];
+    let keys = Set(['key1', 'key2']);
 
-    let expected = ['key2'];
+    let expected = OrderedSet(['key2']);
 
     expect(pipe.transform(keys, schema)).toEqual(expected);
   });

--- a/src/shared/pipes/filter-and-sort-by-schema.pipe.ts
+++ b/src/shared/pipes/filter-and-sort-by-schema.pipe.ts
@@ -24,12 +24,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 import { AppGlobalsService } from '../services';
 
+import { Set, OrderedSet } from 'immutable';
+
 @Pipe({
   name: 'filterAndSortBySchema',
-  // http://stackoverflow.com/questions/34456430/ngfor-doesnt-update-data-with-pipe-in-angular2
-  pure: false
 })
-
 export class FilterAndSortBySchemaPipe implements PipeTransform {
 
   constructor(public appGlobalsService: AppGlobalsService) { }
@@ -37,11 +36,11 @@ export class FilterAndSortBySchemaPipe implements PipeTransform {
   /**
    * It filters out `x_editor_hidden` fields and sorts keys by `x_editor_priority`
    * 
-   * @param {Array<string>} keys
+   * @param {Set<string>} keys
    * @param {Object} schema - the `schema` that has object schema which contains each key in `keys`
-   * @return {Array<string>} - filtered and sortered keys
+   * @return {OrderedSet<string>} - filtered and sorted keys
    */
-  transform(keys: Array<string>, schema: Object): Array<string> {
+  transform(keys: Set<string>, schema: Object): OrderedSet<string> {
     let schemaProps = schema['properties'];
     if (!keys) { return undefined; }
     return keys
@@ -62,6 +61,6 @@ export class FilterAndSortBySchemaPipe implements PipeTransform {
         if (a < b) { return -1; }
         if (a > b) { return 1; }
         return 0;
-      });
+      }) as OrderedSet<string>;
   }
 }

--- a/src/shared/pipes/filter-by-expression.pipe.ts
+++ b/src/shared/pipes/filter-by-expression.pipe.ts
@@ -24,7 +24,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'filterByExpression',
-  pure: false
 })
 export class FilterByExpressionPipe implements PipeTransform {
 

--- a/src/shared/pipes/sanitize-url.pipe.ts
+++ b/src/shared/pipes/sanitize-url.pipe.ts
@@ -25,7 +25,6 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Pipe({
   name: 'sanitizeUrl',
-  pure: false
 })
 
 export class SanitizeUrlPipe implements PipeTransform {

--- a/src/shared/pipes/self-or-empty.pipe.ts
+++ b/src/shared/pipes/self-or-empty.pipe.ts
@@ -27,7 +27,6 @@ import { List } from 'immutable';
 
 @Pipe({
   name: 'selfOrEmpty',
-  pure: false
 })
 
 export class SelfOrEmptyPipe implements PipeTransform {

--- a/src/shared/pipes/underscore-to-space.pipe.ts
+++ b/src/shared/pipes/underscore-to-space.pipe.ts
@@ -24,7 +24,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'underscoreToSpace',
-  pure: false
 })
 export class UnderscoreToSpacePipe implements PipeTransform {
   transform(text: string): string {

--- a/src/table-list-field/table-list-field.component.ts
+++ b/src/table-list-field/table-list-field.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
-import { List, Map } from 'immutable';
+import { List, Map, Set } from 'immutable';
 
 import { AbstractListFieldComponent } from '../abstract-list-field';
 
@@ -42,7 +42,7 @@ export class TableListFieldComponent extends AbstractListFieldComponent implemen
   @Input() schema: Object;
   @Input() path: Array<any>;
 
-  keys: Array<string>;
+  keys: Set<string>;
 
   constructor(public appGlobalsService: AppGlobalsService,
     public jsonStoreService: JsonStoreService,
@@ -53,16 +53,13 @@ export class TableListFieldComponent extends AbstractListFieldComponent implemen
   ngOnInit() {
     super.ngOnInit();
     // all unique keys that are present in at least single element
-    this.keys = Array.from(
-      new Set(
-        this.values
-          .map(object => object.keySeq().toArray())
-          .reduce((pre, cur) => pre.concat(cur), []))
-    );
+    this.keys = Set(this.values
+      .map(object => object.keySeq().toArray())
+      .reduce((pre, cur) => pre.concat(cur), []));
   }
 
   onFieldAdd(field: string) {
-    this.keys.push(field);
+    this.keys = this.keys.add(field);
     setTimeout(() => {
       this.tabIndexService.sortAndSynchronizeTabIndexes();
     });

--- a/src/tree-menu/tree-menu-item.component.ts
+++ b/src/tree-menu/tree-menu-item.component.ts
@@ -24,7 +24,7 @@ import { Component, Input, OnInit, OnChanges, SimpleChanges, ChangeDetectionStra
 
 import { AbstractTrackerComponent } from '../abstract-tracker';
 
-import { Map } from 'immutable';
+import { Map, Set } from 'immutable';
 
 import { DomUtilService, WindowHrefService } from '../shared/services';
 
@@ -44,7 +44,7 @@ export class TreeMenuItemComponent extends AbstractTrackerComponent implements O
   @Input() path: string;
 
   // defined only if schmea.type equals to 'object'
-  keys: Array<string>;
+  keys: Set<string>;
 
   private isCollapsed: boolean = true;
   private href: string;
@@ -62,7 +62,7 @@ export class TreeMenuItemComponent extends AbstractTrackerComponent implements O
     let valueChange = changes['value'];
     if (valueChange && this.schema['type'] === 'object') {
       let currentValue: Map<string, any> = valueChange.currentValue;
-      this.keys = currentValue.keySeq().toArray();
+      this.keys = currentValue.keySeq().toSet();
     }
   }
 

--- a/src/tree-menu/tree-menu.component.ts
+++ b/src/tree-menu/tree-menu.component.ts
@@ -22,7 +22,7 @@
 
 import { Component, Input, OnChanges, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
 
-import { Map } from 'immutable';
+import { Map, Set } from 'immutable';
 
 import { AbstractTrackerComponent } from '../abstract-tracker';
 
@@ -41,7 +41,7 @@ export class TreeMenuComponent extends AbstractTrackerComponent implements OnCha
   @Input() record: Map<string, any>;
   @Input() schema: Object;
 
-  keys: Array<string>;
+  keys: Set<string>;
 
   private prefixOrPath: string = '';
 
@@ -54,7 +54,7 @@ export class TreeMenuComponent extends AbstractTrackerComponent implements OnCha
     let recordChange = changes['record'];
     if (recordChange) {
       let currentRecord: Map<string, any> = recordChange.currentValue;
-      this.keys = currentRecord.keySeq().toArray();
+      this.keys = currentRecord.keySeq().toSet();
     }
   }
 


### PR DESCRIPTION
* Fixes #89

* Purifies pipes that take primitive arguments.

* Changes pipe arguments from Array to Immutable.Set
and purify those pipes.

* Changes `keys` type in components from Array to Immutable.Set
so that it can be passed to pipes.