### PR TITLE
add font-awesome and replace unicode icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Here is a live example of ng2-json-editor: [https://inveniosoftware-contrib.gith
 npm install --save ng2-json-editor
 ```
 
+#### Style Requirements
+
+- [Bootstrap](http://getbootstrap.com/)
+- [Font Awesone](http://fontawesome.io/)
+
+Styles above must be available globally in your application, if you are using [Angular CLI](https://cli.angular.io/) you can have a look at example-app's [angular-cli.json](./angular-cli.json) to
+see how to include those styles in your application. 
+
 ### Import
 
 ```typescript

--- a/angular-cli.json
+++ b/angular-cli.json
@@ -16,7 +16,9 @@
       "tsconfig": "tsconfig.json",
       "mobile": false,
       "styles": [
-        "styles.scss"
+        "styles.scss",
+        "../node_modules/font-awesome/css/font-awesome.css",
+        "../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap.scss"
       ],
       "scripts": [],
       "environments": {

--- a/example/app/app.component.scss
+++ b/example/app/app.component.scss
@@ -1,1 +1,0 @@
-@import '~bootstrap-sass/assets/stylesheets/_bootstrap.scss';

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "core-js": "^2.4.1",
     "coveralls": "^2.11.12",
     "del": "^2.2.2",
+    "font-awesome": "^4.7.0",
     "gulp": "^3.9.1",
     "gulp-ext-replace": "^0.3.0",
     "gulp-ngc": "^0.1.2",

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -5,7 +5,9 @@
       <td class="form-group navigator-item-left">
         <div class="input-group input-group-sm">
           <span class="input-group-btn">
-            <button type="button" class="btn btn-default" (click)="onFindClick()">⚲</button>
+            <button type="button" class="btn btn-default find-button" (click)="onFindClick()">
+              <i class="fa fa-search" aria-hidden="true"></i>
+            </button>
           </span>
           <input type="search" class="form-control" [(ngModel)]="findExpression" (keypress)="onFindInputKeypress($event.key)" placeholder="Find"
           />
@@ -60,12 +62,17 @@
         <!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
         <tr *ngIf="values.size > 0">
           <td class="button-holder">
-            <add-field-dropdown [fields]="keys.get(i)" [pathString]="getElementPathString(pIndex)" (onFieldAdd)="onFieldAdd(i, $event)" [schema]="schema.items.properties">+</add-field-dropdown>
+            <add-field-dropdown [fields]="keys.get(i)" [pathString]="getElementPathString(pIndex)" (onFieldAdd)="onFieldAdd(i, $event)"
+              [schema]="schema.items.properties">+</add-field-dropdown>
           </td>
           <td class="button-holder button-holder-complex-list-actions">
             <button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(pIndex)">&times;</button>
-            <button *ngIf="pIndex > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(pIndex, -1)">▲</button>
-            <button *ngIf="pIndex < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(pIndex, 1)">▼</button>
+            <button *ngIf="pIndex > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(pIndex, -1)">
+              <i class="fa fa-chevron-up" aria-hidden="true"></i>
+            </button>
+            <button *ngIf="pIndex < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(pIndex, 1)">
+              <i class="fa fa-chevron-down" aria-hidden="true"></i>
+            </button>
           </td>
         </tr>
       </table>

--- a/src/complex-list-field/complex-list-field.component.scss
+++ b/src/complex-list-field/complex-list-field.component.scss
@@ -34,3 +34,12 @@ $navigator-item-padding: 13px;
 .borderless {
   border: none;
 }
+
+.find-button {
+  color: darkslategray;
+  opacity: 0.83;
+  
+  .fa-search {
+    opacity: 0.83;
+  }
+}

--- a/src/editor-previewer/editor-previewer.component.html
+++ b/src/editor-previewer/editor-previewer.component.html
@@ -5,7 +5,9 @@
       <div [ngSwitch]="preview.type">
         <div *ngSwitchCase="'html'" class="preview-container">
           <template tabHeading>
-            <span class="preview-link" (click)="openUrlInNewTab(preview.url)">&#10138;</span>
+            <span class="preview-link" (click)="openUrlInNewTab(preview.url)">
+              <i class="fa fa-external-link"></i>
+            </span>
           </template>
           <html-view [url]="preview.url"></html-view>
         </div>

--- a/src/modal-view/modal-view.component.html
+++ b/src/modal-view/modal-view.component.html
@@ -2,16 +2,16 @@
   <div class="modal-dialog modal-lg">
     <div *ngIf="options" class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" (click)="modal.hide()">
-          <span>&times;</span>
-        </button>
+        <button type="button" class="close" (click)="modal.hide()">&times;</button>
         <h4 class="modal-title">{{options.title}}</h4>
       </div>
       <div class="modal-body">
         <div [innerHTML]="options.bodyHtml"></div>
         <div [ngSwitch]="options.type">
           <div *ngSwitchCase="'confirm'">
-            <button class="btn btn-default" (click)="options.onConfirm();">Confirm</button>
+            <button class="btn btn-default" (click)="options.onConfirm();">
+              Confirm <i class="fa fa-check"></i>
+            </button>
           </div>
         </div>
       </div>

--- a/src/primitive-field/primitive-field.component.html
+++ b/src/primitive-field/primitive-field.component.html
@@ -33,8 +33,12 @@
         </div>
       </td>
       <td class="link-button-container">
-        <a *ngIf="schema.linkBuilder" class="no-decoration" target="_blank" [href]="schema.linkBuilder(value)">🔗</a>
-        <a *ngIf="!schema.linkBuilder && schema.format === 'url'" class="no-decoration" target="_blank" [href]="value">🔗</a>
+        <a *ngIf="schema.linkBuilder" class="no-decoration" target="_blank" [href]="schema.linkBuilder(value)">
+          <i class="fa fa-link" aria-hidden="true"></i>
+        </a>
+        <a *ngIf="!schema.linkBuilder && schema.format === 'url'" class="no-decoration" target="_blank" [href]="value">
+          <i class="fa fa-link" aria-hidden="true"></i>
+        </a>
       </td>
     </tr>
   </table>

--- a/src/primitive-list-field/primitive-list-field.component.html
+++ b/src/primitive-list-field/primitive-list-field.component.html
@@ -8,9 +8,15 @@
 
         <!-- UP/DOWN and DELETE buttons for each row -->
         <td *ngIf="values.size > 0" class="button-holder">
-          <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
-          <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
-          <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">▼</button>
+          <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">
+            &times;
+          </button>
+          <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">
+            <i class="fa fa-chevron-up" aria-hidden="true"></i>
+          </button>
+          <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">
+            <i class="fa fa-chevron-down" aria-hidden="true"></i>
+          </button>
         </td>
       </tr>
     </table>

--- a/src/table-list-field/table-list-field.component.html
+++ b/src/table-list-field/table-list-field.component.html
@@ -8,25 +8,33 @@
           </th>
 
           <th class="button-holder">
-            <add-field-dropdown *ngIf="values.size > 0" [fields]="keys" [pathString]="getElementPathString(0)" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.items.properties">+</add-field-dropdown>
+            <add-field-dropdown *ngIf="values.size > 0" [fields]="keys" [pathString]="getElementPathString(0)" (onFieldAdd)="onFieldAdd($event)"
+              [schema]="schema.items.properties">+</add-field-dropdown>
           </th>
 
         </tr>
       </thead>
       <tr *ngFor="let row of values; let i = index; trackBy:trackByFunction" [id]="getElementPathString(i)">
         <!-- Element value -->
-        <td *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction" [style.width]="schema.items.properties[key].columnWidth + '%'">
+        <td *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByFunction"
+          [style.width]="schema.items.properties[key].columnWidth + '%'">
           <any-type-field [value]="row.get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
             [path]="getValuePath(i, key)"></any-type-field>
-          <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(i, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
-        </td>
+            <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(i, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
+            </td>
 
-        <!-- UP/DOWN and DELETE buttons for each row -->
-        <td *ngIf="values.size > 0" class="button-holder">
-          <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">&times;</button>
-          <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">▲</button>
-          <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">▼</button>
-        </td>
+            <!-- UP/DOWN and DELETE buttons for each row -->
+            <td *ngIf="values.size > 0" class="button-holder">
+              <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">
+            &times;
+          </button>
+              <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">
+            <i class="fa fa-chevron-up" aria-hidden="true"></i>
+          </button>
+              <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">
+            <i class="fa fa-chevron-down" aria-hidden="true"></i>
+          </button>
+            </td>
       </tr>
       <tr>
       </tr>


### PR DESCRIPTION
* Adds font-awesome to example and replaces unicode icons with it.

* Documents styling dependencies.

### Find button
![screen shot 2017-02-07 at 10 21 43](https://cloud.githubusercontent.com/assets/4868667/22685475/c08c42de-ed20-11e6-935a-f90e8e31d8b6.png)

### Link button
![screen shot 2017-02-07 at 10 05 34](https://cloud.githubusercontent.com/assets/4868667/22685477/c090c7b4-ed20-11e6-955d-6be01bfbd623.png)

### Up and down buttons
![screen shot 2017-02-07 at 10 05 38](https://cloud.githubusercontent.com/assets/4868667/22685476/c08c970c-ed20-11e6-860a-c91f57218e51.png)

### Modal confirm button
![screen shot 2017-02-07 at 10 06 25](https://cloud.githubusercontent.com/assets/4868667/22685474/c08c2c9a-ed20-11e6-9488-2a23c154add1.png)

### Tab external link
![screen shot 2017-02-07 at 10 05 24](https://cloud.githubusercontent.com/assets/4868667/22685550/00d429ba-ed21-11e6-85a5-a465511b0108.png)