### PR TITLE
fix-issue-179: Fix slow performance issue

### DIFF
--- a/src/abstract-list-field/abstract-list-field.component.ts
+++ b/src/abstract-list-field/abstract-list-field.component.ts
@@ -25,6 +25,7 @@ import { List } from 'immutable';
 import { AbstractFieldComponent } from '../abstract-field';
 
 import { JsonStoreService, AppGlobalsService, TabIndexService, PathUtilService } from '../shared/services';
+import { PathCache } from '../shared/interfaces';
 
 /**
  * Abstract component to share code of common operations of all array fields
@@ -37,6 +38,7 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
   values: List<any>;
   schema: Object;
   path: Array<any>;
+  pathCache: PathCache = {};
 
   constructor(public appGlobalsService: AppGlobalsService,
     public jsonStoreService: JsonStoreService,
@@ -76,7 +78,11 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
    * Returns path of the property of an element at index.
    */
   getValuePath(index: number, property: string): Array<any> {
-    return this.path.concat(index, property);
+    let valuePathString = `${this.getElementPathString(index)}${this.pathUtilService.separator}${property}`;
+    if (!this.pathCache[valuePathString]) {
+      this.pathCache[valuePathString] = this.path.concat(index, property);
+    }
+    return this.pathCache[valuePathString];
   }
 
   getElementPathString(index: number): string {

--- a/src/json-editor.component.ts
+++ b/src/json-editor.component.ts
@@ -47,7 +47,7 @@ import {
   ShortcutService
 } from './shared/services';
 
-import { JsonEditorConfig, Preview, SchemaValidationErrors } from './shared/interfaces';
+import { JsonEditorConfig, Preview, SchemaValidationErrors, PathCache } from './shared/interfaces';
 
 
 @Component({
@@ -73,6 +73,7 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
   previews: Array<Preview> = [];
   isPreviewerHidden: boolean;
   keys: Set<string>;
+  pathCache: PathCache = {};
 
   constructor(public http: Http,
     public appGlobalsService: AppGlobalsService,
@@ -154,7 +155,10 @@ export class JsonEditorComponent extends AbstractTrackerComponent implements OnI
   }
 
   getPathForField(field: string): Array<any> {
-    return [field];
+    if (!this.pathCache[field]) {
+      this.pathCache[field] = [field];
+    }
+    return this.pathCache[field];
   }
 
   onFieldAdd(field: string) {

--- a/src/object-field/object-field.component.ts
+++ b/src/object-field/object-field.component.ts
@@ -27,6 +27,7 @@ import { Map, Set } from 'immutable';
 import { AbstractFieldComponent } from '../abstract-field';
 
 import { AppGlobalsService, JsonStoreService, PathUtilService } from '../shared/services';
+import { PathCache } from '../shared/interfaces';
 
 @Component({
   selector: 'object-field',
@@ -43,6 +44,7 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
   @Input() path: Array<any>;
 
   keys: Set<string>;
+  pathCache: PathCache = {};
 
   constructor(public appGlobalsService: AppGlobalsService,
     public jsonStoreService: JsonStoreService,
@@ -65,7 +67,10 @@ export class ObjectFieldComponent extends AbstractFieldComponent implements OnIn
   }
 
   getFieldPath(name: string): Array<any> {
-    return this.path.concat(name);
+    if (!this.pathCache[name]) {
+      this.pathCache[name] = this.path.concat(name);
+    }
+    return this.pathCache[name];
   }
 
   onFieldAdd(field: string) {

--- a/src/primitive-list-field/primitive-list-field.component.ts
+++ b/src/primitive-list-field/primitive-list-field.component.ts
@@ -54,6 +54,10 @@ export class PrimitiveListFieldComponent extends AbstractListFieldComponent {
    * @override
    */
   getValuePath(index: number): Array<any> {
-    return this.path.concat(index);
+    let valuePathString = this.getElementPathString(index);
+    if (!this.pathCache[valuePathString]) {
+      this.pathCache[valuePathString] = this.path.concat(index);
+    }
+    return this.pathCache[valuePathString];
   }
 }

--- a/src/shared/interfaces/index.ts
+++ b/src/shared/interfaces/index.ts
@@ -13,3 +13,4 @@ export { OnValueChangeFunction } from './on-value-change-function';
 export { CustomShortcuts } from './custom-shortcuts';
 export { ShortcutConfig } from './shortcut-config';
 export { SchemaValidationErrors } from './schema-validation-errors';
+export { PathCache } from './path-cache';

--- a/src/shared/interfaces/path-cache.ts
+++ b/src/shared/interfaces/path-cache.ts
@@ -1,0 +1,6 @@
+export interface PathCache {
+  /**
+   * Field path in string format as a key and field path in array format as a value
+   */
+  [relativeJsonPointer: string]: Array<string>;
+}


### PR DESCRIPTION
  * Every time that path array was needed a new object was obtained.
    So, angular was re-rendering every time all the components and
    the UI was getting slow when typing. Caching the paths fixed the
    re-rendering process only when a new path was added.
(Closes #179)

Signed-off-by: Zacharias Zacharodimos <zacharias.zacharodimos@cern.ch>