### PR TITLE
refactor component templates

### DIFF
--- a/src/abstract-list-field/abstract-list-field.component.ts
+++ b/src/abstract-list-field/abstract-list-field.component.ts
@@ -51,6 +51,10 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
    */
   moveElement(index: number, direction: number) {
     let newIndex = index + direction;
+    // Do nothing if the last moved down or the first moved up.
+    if (newIndex < 0 || newIndex >= this.values.size) {
+      return;
+    }
     let temp = this.values.get(index);
     this.values = this.values
       .set(index, this.values.get(newIndex))
@@ -67,19 +71,16 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
     let elementPathString = this.getElementPathString(index);
   }
 
-  /**
-   * Returns path of the property of an element at index.
-   */
-  getValuePath(index: number, property: string): Array<any> {
-    let valuePathString = `${this.getElementPathString(index)}${this.pathUtilService.separator}${property}`;
-    if (!this.pathCache[valuePathString]) {
-      this.pathCache[valuePathString] = this.path.concat(index, property);
-    }
-    return this.pathCache[valuePathString];
-  }
-
   getElementPathString(index: number): string {
     return `${this.pathString}${this.pathUtilService.separator}${index}`;
+  }
+
+  getElementPath(index: number): Array<any> {
+    let valuePathString = this.getElementPathString(index);
+    if (!this.pathCache[valuePathString]) {
+      this.pathCache[valuePathString] = this.path.concat(index);
+    }
+    return this.pathCache[valuePathString];
   }
 
 }

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -38,44 +38,12 @@
       </td>
     </tr>
   </table>
+  <!-- Elements -->
   <div *ngFor="let pIndex of paginatedIndices; let i = index; trackBy:trackByElement">
     <div class="complex-list-field-wrapper">
-      <table class="table" [id]="getElementPathString(pIndex)">
-        <tr *ngFor="let key of keys.get(i) | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByElement">
-          <td class="label-holder">
-            <div>
-              <title-dropdown [title]="key | underscoreToSpace" [isDisabled]="schema.items.properties[key].disabled">
-                <li *ngIf="schema.items.properties[key].type === 'array'" class="title-dropdown-item">
-                  <add-new-element-button [path]="getValuePath(pIndex, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
-                </li>
-                <li class="title-dropdown-item">
-                  <button type="button" class="editor-btn-delete editor-btn-delete-text" (click)="deleteField(pIndex, key)">Delete</button>
-                </li>
-              </title-dropdown>
-            </div>
-          </td>
-          <td>
-            <any-type-field [value]="values.get(pIndex).get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
-              [path]="getValuePath(pIndex, key)"></any-type-field>
-          </td>
-        </tr>
-        <!-- ADD-FIELD-FROM-SCHEMA, UP/DOWN and DELETE buttons for each row group -->
-        <tr *ngIf="values.size > 0">
-          <td class="button-holder">
-            <add-field-dropdown [fields]="keys.get(i)" [pathString]="getElementPathString(pIndex)" (onFieldAdd)="onFieldAdd(i, $event)"
-              [schema]="schema.items.properties">+</add-field-dropdown>
-          </td>
-          <td class="button-holder button-holder-complex-list-actions">
-            <button type="button" class="editor-btn-delete editor-btn-delete-complex" (click)="deleteElement(pIndex)">&times;</button>
-            <button *ngIf="pIndex > 0" type="button" class="editor-btn-move-up editor-btn-move-up-complex" (click)="moveElement(pIndex, -1)">
-              <i class="fa fa-chevron-up" aria-hidden="true"></i>
-            </button>
-            <button *ngIf="pIndex < (values.size - 1)" class="editor-btn-move-down editor-btn-move-down-complex" type="button" (click)="moveElement(pIndex, 1)">
-              <i class="fa fa-chevron-down" aria-hidden="true"></i>
-            </button>
-          </td>
-        </tr>
-      </table>
+      <object-field [value]="values.get(pIndex)" [schema]="schema.items" [path]="getElementPath(pIndex)">
+        <list-action-group (onMove)="moveElement(i, $event)" (onDelete)="deleteElement(i)"></list-action-group>
+      </object-field>
     </div>
   </div>
 </div>

--- a/src/complex-list-field/complex-list-field.component.scss
+++ b/src/complex-list-field/complex-list-field.component.scss
@@ -4,10 +4,6 @@
   box-shadow: 0 0 3px 1px rgba(0,0,0,0.25);
 }
 
-.button-holder-complex-list-actions {
-  text-align: right;
-}
-
 .navigator-container {
   width: 100%;
 }

--- a/src/complex-list-field/complex-list-field.component.ts
+++ b/src/complex-list-field/complex-list-field.component.ts
@@ -51,7 +51,6 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   @Input() schema: Object;
   @Input() path: Array<any>;
 
-  keys: List<Set<string>>;
   paginatedIndices: Array<number>;
 
   foundIndices: Array<number>;
@@ -76,7 +75,6 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
       // set all indices as paginated indices if pagination is not enabled.
       this.paginatedIndices = this.values.keySeq().toArray();
     }
-    this.keys = this.getKeysForCurrentPage();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -99,22 +97,7 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
         }
       }
 
-      this.keys = this.getKeysForCurrentPage();
     }
-  }
-
-  onFieldAdd(index: number, field: string) {
-    this.keys = this.keys
-      .update(index, value => value.add(field));
-  }
-
-  deleteField(index: number, field: string) {
-    this.values = this.values.removeIn([index, field]);
-    this.jsonStoreService.setIn(this.path, this.values);
-
-    // remove it from keys too, so that it will not be displayed as empty
-    this.keys = this.keys
-      .update(index, value => value.remove(field));
   }
 
   onFindClick() {
@@ -169,7 +152,6 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   onPageChange(page: number) {
     this.currentPage = page;
     this.paginatedIndices = this.getIndicesForPage(page);
-    this.keys = this.getKeysForCurrentPage();
   }
 
   getIndicesForPage(page: number): Array<number> {
@@ -184,12 +166,6 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
     return indices;
   }
 
-  getKeysForCurrentPage(): List<Set<string>> {
-    return List(
-      this.paginatedIndices
-        .map(pIndex => this.values.get(pIndex).keySeq().toSet())
-    );
-  }
 
   getPageForIndex(index: number): number {
     return Math.floor((index / this.navigator.itemsPerPage) + 1);

--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -92,21 +92,11 @@ table {
     opacity: 0.5;
     padding: 0px;
   }
-
-  &.editor-btn-delete-complex {
-    font-size: 21px;
-  }
 }
 
 .editor-btn-move-down {
   padding-bottom: 0;
 }
-
-.editor-btn-move-up-complex, .editor-btn-move-down-complex {
-    font-size: 14px !important;
-    vertical-align: bottom !important;
-    padding-bottom: 2px !important;
-  }
 
 .editor-btn-move-up, .editor-btn-move-down {
   padding: 0;
@@ -271,4 +261,15 @@ button.btn-toggle {
     top: 0px !important;
     left: 0px !important;
   }
+}
+
+.list-action-group-container {
+	text-align: right;
+	button {
+		font-size: 21px !important;
+	}
+
+	i {
+		font-size: 15px !important;
+	}
 }

--- a/src/json-editor.module.ts
+++ b/src/json-editor.module.ts
@@ -44,12 +44,14 @@ import { PrimitiveListFieldComponent } from './primitive-list-field';
 import { PrimitiveFieldComponent } from './primitive-field';
 import { RefFieldComponent } from './ref-field';
 import { TableListFieldComponent } from './table-list-field';
+import { TableItemFieldComponent } from './table-item-field';
 import { TitleDropdownComponent } from './title-dropdown';
 import {
   TreeMenuComponent,
   TreeMenuItemComponent
 } from './tree-menu';
 import { SearchableDropdownComponent } from './searchable-dropdown';
+import { ListActionGroupComponent } from './list-action-group';
 import { SHARED_PIPES, SHARED_SERVICES, SHARED_DIRECTIVES } from './shared';
 
 @NgModule({
@@ -70,7 +72,9 @@ import { SHARED_PIPES, SHARED_SERVICES, SHARED_DIRECTIVES } from './shared';
     PrimitiveFieldComponent,
     RefFieldComponent,
     SearchableDropdownComponent,
+    ListActionGroupComponent,
     TableListFieldComponent,
+    TableItemFieldComponent,
     TitleDropdownComponent,
     TreeMenuItemComponent,
     TreeMenuComponent,
@@ -103,7 +107,9 @@ export {
   PrimitiveFieldComponent,
   RefFieldComponent,
   SearchableDropdownComponent,
+  ListActionGroupComponent,
   TableListFieldComponent,
+  TableItemFieldComponent,
   TitleDropdownComponent,
   TreeMenuItemComponent,
   TreeMenuComponent,

--- a/src/list-action-group/index.ts
+++ b/src/list-action-group/index.ts
@@ -1,0 +1,1 @@
+export { ListActionGroupComponent } from './list-action-group.component';

--- a/src/list-action-group/list-action-group.component.html
+++ b/src/list-action-group/list-action-group.component.html
@@ -1,0 +1,11 @@
+<div>
+  <button type="button" class="editor-btn-delete" (click)="onDelete.emit()">
+    &times;
+  </button>
+  <button type="button" class="editor-btn-move-up" (click)="onMove.emit(-1)">
+    <i class="fa fa-chevron-up"></i>
+  </button>
+  <button type="button" class="editor-btn-move-down" (click)="onMove.emit(1)">
+    <i class="fa fa-chevron-down"></i>
+  </button>
+</div>

--- a/src/list-action-group/list-action-group.component.ts
+++ b/src/list-action-group/list-action-group.component.ts
@@ -20,31 +20,28 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  Output,
+  EventEmitter,
+  OnInit,
+  ViewEncapsulation,
+  ChangeDetectionStrategy
+} from '@angular/core';
 
-import { List } from 'immutable';
-
-import { AbstractListFieldComponent } from '../abstract-list-field';
-
-import { AppGlobalsService, JsonStoreService, PathUtilService } from '../shared/services';
 
 @Component({
-  selector: 'primitive-list-field',
+  selector: 'list-action-group',
+  encapsulation: ViewEncapsulation.None,
   styleUrls: [
-    './primitive-list-field.component.scss'
+    './list-action-group.component.scss'
   ],
-  templateUrl: './primitive-list-field.component.html',
+  templateUrl: './list-action-group.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PrimitiveListFieldComponent extends AbstractListFieldComponent {
-  @Input() values: List<any>;
-  @Input() schema: Object;
-  @Input() path: Array<any>;
+export class ListActionGroupComponent {
 
-  constructor(public appGlobalsService: AppGlobalsService,
-    public jsonStoreService: JsonStoreService,
-    public pathUtilService: PathUtilService) {
-    super(appGlobalsService, jsonStoreService, pathUtilService);
-  }
+  @Output() onDelete = new EventEmitter<void>();
+  @Output() onMove = new EventEmitter<number>();
 
 }

--- a/src/object-field/object-field.component.html
+++ b/src/object-field/object-field.component.html
@@ -1,30 +1,31 @@
-<div [id]="pathString">
-  <table class="table">
-    <tr *ngFor="let key of keys | addAlwaysShowFields:schema | filterAndSortBySchema:schema; trackBy:trackByElement">
-      <!-- SUB FIELD TITLE MENU -->
-      <td>
-        <div>
-          <title-dropdown [title]="key | underscoreToSpace" [isDisabled]="schema.properties[key].disabled">
-            <li *ngIf="schema.properties[key].type === 'array'" class="title-dropdown-item">
-              <add-new-element-button [path]="getFieldPath(key)" [schema]="schema.properties[key]"></add-new-element-button>
-            </li>
-            <li class="title-dropdown-item">
-              <button type="button" class="editor-btn-delete editor-btn-delete-text" (click)="deleteField(key)">Delete</button>
-            </li>
-          </title-dropdown>
-        </div>
-      </td>
-      <!-- SUB FIELD COMPONENT -->
-      <td>
-        <any-type-field [value]="value.get(key) | selfOrEmpty:schema.properties[key]" [schema]=schema.properties[key] [path]="getFieldPath(key)"></any-type-field>
-      </td>
-    </tr>
-
-    <!-- ADD SUB FIELD FROM SCHEMA DROPDOWN -->
-    <tr>
-      <td class="button-holder">
-        <add-field-dropdown [fields]="keys" [pathString]="pathString" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.properties">+</add-field-dropdown>
-      </td>
-    </tr>
-  </table>
-</div>
+<table [id]="pathString" class="table">
+  <tr *ngFor="let key of keys | addAlwaysShowFields:schema | filterAndSortBySchema:schema; trackBy:trackByElement">
+    <!-- SUB FIELD TITLE MENU -->
+    <td class="label-holder">
+      <div>
+        <title-dropdown [title]="key | underscoreToSpace" [isDisabled]="schema.properties[key].disabled">
+          <li *ngIf="schema.properties[key].type === 'array'" class="title-dropdown-item">
+            <add-new-element-button [path]="getFieldPath(key)" [schema]="schema.properties[key]"></add-new-element-button>
+          </li>
+          <li class="title-dropdown-item">
+            <button type="button" class="editor-btn-delete editor-btn-delete-text" (click)="deleteField(key)">Delete</button>
+          </li>
+        </title-dropdown>
+      </div>
+    </td>
+    <!-- SUB FIELD COMPONENT -->
+    <td>
+      <any-type-field [value]="value.get(key) | selfOrEmpty:schema.properties[key]" [schema]=schema.properties[key] [path]="getFieldPath(key)"></any-type-field>
+    </td>
+  </tr>
+  <!-- ADD SUB FIELD FROM SCHEMA DROPDOWN -->
+  <tr>
+    <td class="button-holder">
+      <add-field-dropdown [fields]="keys" [pathString]="pathString" (onFieldAdd)="onFieldAdd($event)" [schema]="schema.properties">+</add-field-dropdown>
+    </td>
+    <td class="button-holder list-action-group-container">
+      <!-- list-action-group (up/down and delete buttons), Set only if it's an element of an list (complex-list) -->
+      <ng-content></ng-content>
+    </td>
+  </tr>
+</table>

--- a/src/object-field/object-field.component.scss
+++ b/src/object-field/object-field.component.scss
@@ -1,4 +1,3 @@
 table.table {
 	background-color: #f9f9f9;
 }
-

--- a/src/primitive-list-field/primitive-list-field.component.html
+++ b/src/primitive-list-field/primitive-list-field.component.html
@@ -3,20 +3,10 @@
     <table class="table">
       <tr *ngFor="let value of values | selfOrEmpty:schema; let i = index; trackBy:trackByElement">
         <td>
-          <primitive-field [value]="value" [schema]="schema.items" [path]="getValuePath(i)"></primitive-field>
+          <primitive-field [value]="value" [schema]="schema.items" [path]="getElementPath(i)"></primitive-field>
         </td>
-
-        <!-- UP/DOWN and DELETE buttons for each row -->
         <td *ngIf="values.size > 0" class="button-holder">
-          <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">
-            &times;
-          </button>
-          <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">
-            <i class="fa fa-chevron-up" aria-hidden="true"></i>
-          </button>
-          <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">
-            <i class="fa fa-chevron-down" aria-hidden="true"></i>
-          </button>
+          <list-action-group (onMove)="moveElement(i, $event)" (onDelete)="deleteElement(i)"></list-action-group>
         </td>
       </tr>
     </table>

--- a/src/table-item-field/index.ts
+++ b/src/table-item-field/index.ts
@@ -1,0 +1,1 @@
+export { TableItemFieldComponent } from './table-item-field.component';

--- a/src/table-item-field/table-item-field.component.html
+++ b/src/table-item-field/table-item-field.component.html
@@ -1,0 +1,8 @@
+<td *ngFor="let key of keys | addAlwaysShowFields:schema | filterAndSortBySchema:schema; trackBy:trackByElement" [style.width]="schema.properties[key].columnWidth + '%'">
+  <any-type-field [value]="value.get(key) | selfOrEmpty:schema.properties[key]" [schema]="schema.properties[key]" [path]="getFieldPath(key)">
+  </any-type-field>
+  <add-new-element-button *ngIf="schema.properties[key].type === 'array'" [path]="getFieldPath(key)" [schema]="schema.properties[key]">
+  </add-new-element-button>
+</td>
+<!-- td element with list-action-group (up/down and delete buttons) -->
+<ng-content></ng-content>

--- a/src/table-item-field/table-item-field.component.scss
+++ b/src/table-item-field/table-item-field.component.scss
@@ -1,0 +1,4 @@
+td {
+  padding: 0 !important;
+  vertical-align: top !important;
+}

--- a/src/table-item-field/table-item-field.component.ts
+++ b/src/table-item-field/table-item-field.component.ts
@@ -20,31 +20,56 @@
  * as an Intergovernmental Organization or submit itself to any jurisdiction.
 */
 
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  ChangeDetectionStrategy,
+  SimpleChanges
+} from '@angular/core';
 
-import { List } from 'immutable';
+import { List, Set } from 'immutable';
 
-import { AbstractListFieldComponent } from '../abstract-list-field';
+import { AbstractFieldComponent } from '../abstract-field';
 
-import { AppGlobalsService, JsonStoreService, PathUtilService } from '../shared/services';
+import {
+  AppGlobalsService,
+  JsonStoreService,
+  PathUtilService
+} from '../shared/services';
+import { PathCache } from '../shared/interfaces';
 
 @Component({
-  selector: 'primitive-list-field',
+  // Defined as attribute selector not to break table > tr > td html structure
+  // tslint:disable-next-line
+  selector: '[table-item-field]',
   styleUrls: [
-    './primitive-list-field.component.scss'
+    './table-item-field.component.scss'
   ],
-  templateUrl: './primitive-list-field.component.html',
+  templateUrl: './table-item-field.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PrimitiveListFieldComponent extends AbstractListFieldComponent {
-  @Input() values: List<any>;
+export class TableItemFieldComponent extends AbstractFieldComponent {
+
+  @Input() value: Map<string, any>;
   @Input() schema: Object;
   @Input() path: Array<any>;
+  @Input() keys: Set<string>;
+  pathCache: PathCache = {};
 
   constructor(public appGlobalsService: AppGlobalsService,
     public jsonStoreService: JsonStoreService,
     public pathUtilService: PathUtilService) {
-    super(appGlobalsService, jsonStoreService, pathUtilService);
+    super(appGlobalsService, pathUtilService);
+  }
+
+
+  getFieldPath(name: string): Array<any> {
+    if (!this.pathCache[name]) {
+      this.pathCache[name] = this.path.concat(name);
+    }
+    return this.pathCache[name];
   }
 
 }

--- a/src/table-list-field/table-list-field.component.html
+++ b/src/table-list-field/table-list-field.component.html
@@ -6,37 +6,17 @@
           <th *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByElement">
             {{key | underscoreToSpace}}
           </th>
-
           <th class="button-holder">
             <add-field-dropdown *ngIf="values.size > 0" [fields]="keys" [pathString]="getElementPathString(0)" (onFieldAdd)="onFieldAdd($event)"
               [schema]="schema.items.properties">+</add-field-dropdown>
           </th>
-
         </tr>
       </thead>
-      <tr *ngFor="let row of values; let i = index; trackBy:trackByIndex" [id]="getElementPathString(i)">
-        <!-- Element value -->
-        <td *ngFor="let key of keys | addAlwaysShowFields:schema.items | filterAndSortBySchema:schema.items; trackBy:trackByElement"
-          [style.width]="schema.items.properties[key].columnWidth + '%'">
-          <any-type-field [value]="row.get(key) | selfOrEmpty:schema.items.properties[key]" [schema]="schema.items.properties[key]"
-            [path]="getValuePath(i, key)"></any-type-field>
-            <add-new-element-button *ngIf="schema.items.properties[key].type === 'array'" [path]="getValuePath(i, key)" [schema]="schema.items.properties[key]"></add-new-element-button>
-            </td>
-
-            <!-- UP/DOWN and DELETE buttons for each row -->
-            <td *ngIf="values.size > 0" class="button-holder">
-              <button type="button" class="editor-btn-delete" (click)="deleteElement(i)">
-            &times;
-          </button>
-              <button *ngIf="i > 0" type="button" class="editor-btn-move-up" (click)="moveElement(i, -1)">
-            <i class="fa fa-chevron-up" aria-hidden="true"></i>
-          </button>
-              <button *ngIf="i < (values.size - 1)" type="button" class="editor-btn-move-down" (click)="moveElement(i, 1)">
-            <i class="fa fa-chevron-down" aria-hidden="true"></i>
-          </button>
-            </td>
-      </tr>
-      <tr>
+      <tr *ngFor="let value of values; let i = index; trackBy:trackByIndex" table-item-field [id]="getElementPathString(i)" [value]="value"
+        [schema]="schema.items" [path]="getElementPath(i)" [keys]="keys">
+        <td *ngIf="values.size > 0" class="button-holder">
+          <list-action-group (onMove)="moveElement(i, $event)" (onDelete)="deleteElement(i)"></list-action-group>
+        </td>
       </tr>
     </table>
   </div>

--- a/src/table-list-field/table-list-field.component.scss
+++ b/src/table-list-field/table-list-field.component.scss
@@ -9,18 +9,4 @@ table.editable-inner-table {
     border: none;
     color: $label-color;
   }
-
-  div.list-holder {
-    padding: 3px;
-  }
-
-  td {
-    padding: 0 !important;
-    vertical-align: top !important;
-  }
-
-  label {
-    display: inline !important;
-    font-weight: initial !important;
-  }
 }


### PR DESCRIPTION
* Changes the case when a component manages two level in a path
(has two nested ngFor over the value) by re using object-field for
complex-list elements and new table-item-field for table-list elements.

* Adds list-action-group component to share template of up/down and
delete.

* Fix style which is broken because of html structure change.