### PR TITLE
add padding to top-level add-field-dropdown

### DIFF
--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -149,6 +149,7 @@ body, html {
 
     ul.dropdown-menu {
       right: 0px;
+      padding-bottom: 15px;
     }
 
     button.btn-add-field-dropdown {


### PR DESCRIPTION
* Fixes 292

### firefox
<img width="372" alt="screen shot 2017-05-17 at 10 20 59" src="https://cloud.githubusercontent.com/assets/4868667/26145107/8d297772-3aeb-11e7-97cd-1b6217bf403f.png">

###  chrome
![screen shot 2017-05-17 at 10 21 26](https://cloud.githubusercontent.com/assets/4868667/26145108/8d4486a2-3aeb-11e7-8452-eafe8f97c2ff.png)

