### PR TITLE
use schema.componentType in primitive field

### DIFF
--- a/src/primitive-field/primitive-field.component.html
+++ b/src/primitive-field/primitive-field.component.html
@@ -1,4 +1,4 @@
-<div [ngSwitch]="valueType" [id]="pathString">
+<div [ngSwitch]="schema.componentType" [id]="pathString">
   <table class="primitive-field-container">
     <tr [ngClass]="{error: hasErrors}">
       <ng-template #errorsTooltipTemplate>

--- a/src/primitive-field/primitive-field.component.spec.ts
+++ b/src/primitive-field/primitive-field.component.spec.ts
@@ -108,7 +108,8 @@ describe('PrimitiveFieldComponent', () => {
     component.value = 'defaultStringValue';
     component.path = ['default', 'path'];
     component.schema = {
-      type: 'string'
+      type: 'string',
+      componentType: 'string'
     };
     fixture.detectChanges();
 

--- a/src/primitive-field/primitive-field.component.ts
+++ b/src/primitive-field/primitive-field.component.ts
@@ -64,10 +64,6 @@ export class PrimitiveFieldComponent extends AbstractFieldComponent {
     super(appGlobalsService, pathUtilService, changeDetectorRef);
   }
 
-  get valueType(): string {
-    return this.componentTypeService.getComponentType(this.schema);
-  }
-
   commitValueChange() {
     this.domUtilService.clearHighlight();
     let errors = this.schemaValidationService.validateValue(this.value, this.schema);


### PR DESCRIPTION
* Uses schema.componentType in primitive field to avoid using
getComponentType unnecessarily.