### PR TITLE
skip validation and remove field if string is empty

### DIFF
--- a/src/abstract-list-field/abstract-list-field.component.ts
+++ b/src/abstract-list-field/abstract-list-field.component.ts
@@ -65,7 +65,8 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
    * @param {number} index - Index of the element to be deleted
    */
   deleteElement(index: number) {
-    this.jsonStoreService.setIn(this.path, this.values.remove(index));
+    let elementPath = this.path.concat(index);
+    this.jsonStoreService.removeIn(elementPath);
     this.values = this.jsonStoreService.getIn(this.path);
   }
 

--- a/src/object-field/object-field.component.ts
+++ b/src/object-field/object-field.component.ts
@@ -56,7 +56,8 @@ export class ObjectFieldComponent extends AbstractFieldComponent {
   }
 
   deleteField(name: string) {
-    this.jsonStoreService.removeIn(this.path);
+    let fieldPath = this.path.concat(name);
+    this.jsonStoreService.removeIn(fieldPath);
 
     this.keysStoreService.deleteKey(this.pathString, name);
   }

--- a/src/primitive-field/primitive-field.component.ts
+++ b/src/primitive-field/primitive-field.component.ts
@@ -70,10 +70,15 @@ export class PrimitiveFieldComponent extends AbstractFieldComponent {
 
   commitValueChange() {
     this.domUtilService.clearHighlight();
-    let errors = this.schemaValidationService.validateValue(this.value, this.schema);
+
+    // don't validate if value is empty
+    if (this.value) {
+      let errors = this.schemaValidationService.validateValue(this.value, this.schema);
+      this.internalErrors = errors;
+      this.appGlobalsService.extendInternalErrors(this.pathString, errors);
+    }
+
     this.jsonStoreService.setIn(this.path, this.value);
-    this.internalErrors = errors;
-    this.appGlobalsService.extendInternalErrors(this.pathString, errors);
   }
 
   onKeypress(event: KeyboardEvent) {

--- a/src/shared/services/json-store.service.spec.ts
+++ b/src/shared/services/json-store.service.spec.ts
@@ -157,4 +157,15 @@ describe('JsonStoreService', () => {
 
     service.rollbackJsonFromHistory();
   });
+
+  it('should removeIn if setIn value is empty string', () => {
+    let json = fromJS({
+      foo: 'bar'
+    });
+    let path = ['foo'];
+    service.setJson(json);
+    spyOn(service, 'removeIn');
+    service.setIn(path, '');
+    expect(service.removeIn).toHaveBeenCalledWith(path);
+  });
 });

--- a/src/shared/services/json-store.service.ts
+++ b/src/shared/services/json-store.service.ts
@@ -14,6 +14,12 @@ export class JsonStoreService implements NestedStore {
 
 
   setIn(path: Array<any>, value: any) {
+    // if value is undefined or empty string
+    if (!value) {
+      this.removeIn(path);
+      return;
+    }
+
     // immutablejs setIn creates Map for keys that don't exist in path
     // therefore List() should be set manually for some of those keys.
     for (let i = 0; i < path.length - 1; i++) {


### PR DESCRIPTION
* Replaces setIn with removeIn in some places.

* Fixes #235

* Removes a primitive field from an object or primitive list if value
is empty string or undefined. This reduces number of accidental empty
strings in the record and allows users to delete property of items of
table list.

@jmartinm @zzacharo please play with it locally.