### PR TITLE
refactor keys-store

### DIFF
--- a/src/autocomplete-input/autocomplete-input.component.spec.ts
+++ b/src/autocomplete-input/autocomplete-input.component.spec.ts
@@ -37,7 +37,8 @@ import {
   PathUtilService,
   AppGlobalsService,
   ErrorMapUtilService,
-  KeysStoreService
+  KeysStoreService,
+  JsonSchemaService
 } from '../shared/services';
 import { AutocompletionResult, AutocompletionConfig } from '../shared/interfaces';
 
@@ -78,7 +79,8 @@ describe('AutocompleteInputComponent', () => {
         JsonStoreService,
         KeysStoreService,
         PathUtilService,
-        ErrorMapUtilService
+        ErrorMapUtilService,
+        JsonSchemaService
       ]
     }).compileComponents();
   }));

--- a/src/primitive-field/primitive-field.component.spec.ts
+++ b/src/primitive-field/primitive-field.component.spec.ts
@@ -42,7 +42,8 @@ import {
   PathUtilService,
   DomUtilService,
   TabsUtilService,
-  ErrorMapUtilService
+  ErrorMapUtilService,
+  JsonSchemaService
 } from '../shared/services';
 
 import { ContentModelDirective } from '../shared/directives';
@@ -97,6 +98,7 @@ describe('PrimitiveFieldComponent', () => {
         ErrorMapUtilService,
         KatexService,
         KeysStoreService,
+        JsonSchemaService,
         { provide: JsonStoreService, useClass: MockJsonStoreService }
       ]
     }).compileComponents();


### PR DESCRIPTION
* Refactors keys-store addKey method by making schema param optional so
that it can be used by parent apps (in config's callback functions)
easily.