### PR TITLE
add non immutable support to json-store.service

### DIFF
--- a/src/shared/services/json-store.service.spec.ts
+++ b/src/shared/services/json-store.service.spec.ts
@@ -166,4 +166,46 @@ describe('JsonStoreService', () => {
 
     service.addIn(path, value);
   });
+
+  it('should addIn an object', () => {
+    let json = fromJS({
+      aList: []
+    });
+    service.setJson(json);
+
+    let value = {
+      foo: 'bar'
+    };
+    let path = ['aList', '-'];
+    let expected = fromJS({
+      aList: [
+        { foo: 'bar' }
+      ]
+    });
+    service.jsonChange.subscribe(changedJson => {
+      expect(changedJson.equals(expected)).toBeTruthy();
+    });
+
+    service.addIn(path, value);
+  });
+
+  it('should setIn an array', () => {
+    let json = fromJS({
+      aMap: {}
+    });
+    service.setJson(json);
+
+    let value = [1];
+    let path = ['aMap', 'aList'];
+    let expected = fromJS({
+      aMap: {
+        aList: [1]
+      }
+    });
+    service.jsonChange.subscribe(changedJson => {
+      expect(changedJson.equals(expected)).toBeTruthy();
+    });
+
+    service.setIn(path, value);
+  });
 });

--- a/src/shared/services/json-store.service.ts
+++ b/src/shared/services/json-store.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Map, List } from 'immutable';
+import { Map, List, fromJS } from 'immutable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 
 import { PathUtilService } from './path-util.service';
@@ -22,6 +22,8 @@ export class JsonStoreService {
       this.removeIn(path);
       return;
     }
+
+    value = this.toImmutable(value);
 
     // immutablejs setIn creates Map for keys that don't exist in path
     // therefore List() should be set manually for some of those keys.
@@ -56,7 +58,8 @@ export class JsonStoreService {
     let isInsert = typeof lastPathElement === 'number' || lastPathElement === '-';
     if (isInsert) {
       let pathWithoutIndex = path.slice(0, path.length - 1);
-      let list = this.getIn(pathWithoutIndex) as List<any>;
+      let list = this.getIn(pathWithoutIndex) as List<any> || List();
+      value = this.toImmutable(value);
       list = lastPathElement === '-' ? list.push(value) : list.insert(lastPathElement, value);
       this.setIn(pathWithoutIndex, list);
     } else {
@@ -97,5 +100,15 @@ export class JsonStoreService {
 
   get jsonChange(): ReplaySubject<Map<string, any>> {
     return this._jsonChange;
+  }
+
+  /**
+   * Converts the value to immutable if it is not an immutable.
+   */
+  private toImmutable(value: any): any {
+    if (typeof value === 'object' && !(List.isList(value) || Map.isMap(value))) {
+      return fromJS(value);
+    }
+    return value;
   }
 }


### PR DESCRIPTION
* Now a javascript object or array can be passed to addIn and setIn
functions, and they are later converted to Immutable. Thanks to this
parent app doesn't need to care about complexity of immutable data
structures.