### PR TITLE
updage to ngx-boostrap and fix #275

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "katex": "^0.7.1",
     "lodash": "4.17.2",
     "mousetrap": "^1.6.0",
-    "ng2-bootstrap": "2.0.0-beta.0",
-    "ng2-slide-toggle": "^1.0.0"
+    "ng2-slide-toggle": "^1.0.0",
+    "ngx-bootstrap": "2.0.0-beta.1"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0",
@@ -63,11 +63,12 @@
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
+    "@types/diff": "3.2.0",
     "@types/jasmine": "2.5.38",
     "@types/katex": "^0.5.0",
+    "@types/lodash": "4.14.57",
     "@types/mousetrap": "^1.5.32",
     "@types/node": "~6.0.60",
-    "@types/lodash": "4.14.57",
     "bootstrap-sass": "^3.3.7",
     "codelyzer": "~2.0.0-beta.1",
     "copyfiles": "^1.2.0",

--- a/src/add-field-dropdown/add-field-dropdown.component.spec.ts
+++ b/src/add-field-dropdown/add-field-dropdown.component.spec.ts
@@ -22,7 +22,7 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Set } from 'immutable';
-import { Ng2BootstrapModule } from 'ng2-bootstrap';
+import { Ng2BootstrapModule } from 'ngx-bootstrap';
 
 import { AddFieldDropdownComponent } from './add-field-dropdown.component';
 import { DifferentKeysPipe, FilterByExpressionPipe } from '../shared/pipes';

--- a/src/autocomplete-input/autocomplete-input.component.spec.ts
+++ b/src/autocomplete-input/autocomplete-input.component.spec.ts
@@ -28,7 +28,7 @@ import {
 } from '@angular/core/testing';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
-import { Ng2BootstrapModule } from 'ng2-bootstrap';
+import { Ng2BootstrapModule } from 'ngx-bootstrap';
 
 import { AutocompleteInputComponent } from '../autocomplete-input';
 import {

--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -154,11 +154,6 @@ body, html {
     }
   }
 
-  // fixes ng2-bootstrap dropdown position
-  bs-dropdown-container {
-    position: inherit !important;
-  }
-
   .editor-btn-delete {
     font-weight: bold;
     line-height: 1;

--- a/src/json-editor.module.ts
+++ b/src/json-editor.module.ts
@@ -25,8 +25,15 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
-// TODO: investigate if all modules or only used ones are in the bundle of the example app.
-import { Ng2BootstrapModule } from 'ng2-bootstrap';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { PopoverModule } from 'ngx-bootstrap/popover';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { PaginationModule } from 'ngx-bootstrap/pagination';
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
+
+
 import { SlideToggleModule } from 'ng2-slide-toggle';
 
 import {
@@ -102,7 +109,13 @@ import { AddPatchViewComponent } from './add-patch-view';
   ],
   exports: [JsonEditorComponent],
   imports: [
-    Ng2BootstrapModule.forRoot(),
+    TooltipModule.forRoot(),
+    PopoverModule.forRoot(),
+    BsDropdownModule.forRoot(),
+    PaginationModule.forRoot(),
+    ModalModule.forRoot(),
+    TabsModule.forRoot(),
+    TypeaheadModule.forRoot(),
     SlideToggleModule,
     CommonModule,
     FormsModule,

--- a/src/modal-view/modal-view.component.ts
+++ b/src/modal-view/modal-view.component.ts
@@ -21,7 +21,7 @@
 */
 
 import { Component, ChangeDetectorRef, ChangeDetectionStrategy, ViewChild } from '@angular/core';
-import { ModalDirective } from 'ng2-bootstrap/ng2-bootstrap';
+import { ModalDirective } from 'ngx-bootstrap';
 
 import { ModalService } from '../shared/services';
 import { ModalOptions } from '../shared/interfaces';

--- a/src/primitive-field/primitive-field.component.spec.ts
+++ b/src/primitive-field/primitive-field.component.spec.ts
@@ -25,7 +25,7 @@ import {
   ComponentFixture,
   TestBed
 } from '@angular/core/testing';
-import { Ng2BootstrapModule } from 'ng2-bootstrap';
+import { Ng2BootstrapModule } from 'ngx-bootstrap';
 import { Observable } from 'rxjs/Observable';
 
 import { SearchableDropdownComponent } from '../searchable-dropdown';

--- a/src/searchable-dropdown/searchable-dropdown.component.spec.ts
+++ b/src/searchable-dropdown/searchable-dropdown.component.spec.ts
@@ -25,7 +25,7 @@ import {
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
-import { Ng2BootstrapModule } from 'ng2-bootstrap';
+import { Ng2BootstrapModule } from 'ngx-bootstrap';
 
 import { SearchableDropdownComponent } from './searchable-dropdown.component';
 import { FilterByExpressionPipe } from '../shared/pipes';

--- a/src/title-dropdown/title-dropdown.component.scss
+++ b/src/title-dropdown/title-dropdown.component.scss
@@ -18,4 +18,5 @@
 
 .dropdown-menu {
   min-width: 120px;
+  top: initial;
 }


### PR DESCRIPTION
* Changes ng2-bootstrap to ngx-bootstrap.

* Upgrades the version of the package to -beta.1
becuase latest (-beta.3) is breaking popovers.

* Adds missing types for diff library

* Fixes #275