### PR TITLE
swap keys while moving complex list items

### DIFF
--- a/src/abstract-list-field/abstract-list-field.component.ts
+++ b/src/abstract-list-field/abstract-list-field.component.ts
@@ -47,24 +47,15 @@ export abstract class AbstractListFieldComponent extends AbstractFieldComponent 
   }
 
   /**
-   * @param {number} index - Index of the element that is moved
-   * @param {number} direction - Movement direction. -1 for UP, +1 for DOWN
+   * @param index - Index of the element that is moved
+   * @param  direction - Movement direction. -1 for UP, +1 for DOWN
    */
   moveElement(index: number, direction: number) {
-    let newIndex = index + direction;
-    // Do nothing if the last moved down or the first moved up.
-    if (newIndex < 0 || newIndex >= this.values.size) {
-      return;
-    }
-    let temp = this.values.get(index);
-    this.values = this.values
-      .set(index, this.values.get(newIndex))
-      .set(newIndex, temp);
-    this.jsonStoreService.setIn(this.path, this.values);
+    this.jsonStoreService.moveIn(this.path, index, direction);
   }
 
   /**
-   * @param {number} index - Index of the element to be deleted
+   * @param index - Index of the element to be deleted
    */
   deleteElement(index: number) {
     let elementPath = this.path.concat(index);

--- a/src/shared/services/json-store.service.ts
+++ b/src/shared/services/json-store.service.ts
@@ -47,7 +47,7 @@ export class JsonStoreService {
     return this.json.getIn(path);
   }
 
-  removeIn(path: Array<any>): any {
+  removeIn(path: Array<any>) {
     this.history.push({
       path: this.pathUtilService.toPathString(path),
       op: 'add',
@@ -79,6 +79,30 @@ export class JsonStoreService {
     } else {
       this.setIn(path, value);
     }
+  }
+
+  /**
+   * Moves the element at given index UP or DOWN within the list
+   * @param listPath path to a list in json
+   * @param index index of the element that is being moved
+   * @param direction 1 for DOWN, -1 for UP movement
+   * @return new path of the moved element
+   */
+  moveIn(listPath: Array<any>, index: number, direction: number): Array<any> {
+    let list = this.getIn(listPath);
+    let newIndex = index + direction;
+    if (newIndex >= list.size || newIndex < 0) {
+      newIndex = list.size - Math.abs(newIndex);
+    }
+    let temp = list.get(index);
+    list = list
+      .set(index, list.get(newIndex))
+      .set(newIndex, temp);
+    this.setIn(listPath, list);
+
+    this.keysStoreService.swapListElementKeys(listPath, index, newIndex);
+
+    return listPath.concat(newIndex);
   }
 
   setJson(json: Map<string, any>) {

--- a/src/shared/services/shortcut-action.service.ts
+++ b/src/shared/services/shortcut-action.service.ts
@@ -105,28 +105,11 @@ export class ShortcutActionService {
   private move(path: Array<any>, direction: number, root = false): void {
     this.domUtilService.blurFirstEditableChildById(this.pathUtilService.toPathString(path));
     let index = this.pathUtilService.getElementIndexInForwardOrReversePath(path, root);
-    path = this.moveElement(index, direction, this.pathUtilService.getNearestOrRootArrayParentInPath(path, root));
+    path = this.jsonStoreService.moveIn(this.pathUtilService.getNearestOrRootArrayParentInPath(path, root), index, direction);
     let pathString = this.pathUtilService.toPathString(path);
     setTimeout(() => {
       this.focusElementInPath(pathString);
     });
-  }
-
-  /**
-   * @param {number} index - Index of the element that is moved
-   * @param {number} direction - Movement direction. -1 for UP, +1 for DOWN
-   * @returns {number} - Returns the new path of the moved element
-   */
-  private moveElement(index: number, direction: number, path: Array<any>): Array<any> {
-    let values = this.jsonStoreService.getIn(path);
-    let newIndex = ((index + direction) < values.size &&
-      (index + direction) >= 0) ? index + direction : values.size - Math.abs((index + direction));
-    let temp = values.get(index);
-    values = values
-      .set(index, values.get(newIndex))
-      .set(newIndex, temp);
-    this.jsonStoreService.setIn(path, values);
-    return path.concat(newIndex);
   }
 
   deleteAction(path: Array<any>) {


### PR DESCRIPTION
* Fixes #354

* Adds moveIn utility to json-store so that moving will be shared btw
components and shortcuts.

* Adds test for deleteKey.

* Removes types from method comments.