### PR TITLE
add switch to see only items with edit form

### DIFF
--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -60,7 +60,9 @@
             <add-nested-field-dropdown [pathString]="pathString + '/' + item.index" [schema]="schema.items" [isDisabled]="disabled"></add-nested-field-dropdown>
           </div>
           <div class="col-md-6 right">
-            <list-action-group (onMove)="moveElement(item.index, $event)" (onDelete)="deleteElement(item.index)" [canMove]="schema.sortable" [isDisabled]="disabled"></list-action-group>
+            <list-action-group (onMove)="moveElement(item.index, $event)" (onDelete)="deleteElement(item.index)" [canMove]="sortable"
+              [isDisabled]="disabled">
+            </list-action-group>
           </div>
         </div>
       </span>

--- a/src/complex-list-field/complex-list-field.component.html
+++ b/src/complex-list-field/complex-list-field.component.html
@@ -20,21 +20,25 @@
           <span *ngSwitchCase="0">
               Nothing found
           </span>
-          <span *ngSwitchDefault>
+        <span *ngSwitchDefault>
               {{currentFound + 1}} of {{foundIndices.length}}
           </span>
         </span>
       </div>
+    </div>
+    <div class="btn-group">
+      <label class="btn btn-switch" [class.active]="shouldDisplayOnlyEditFormItems" (click)="shouldDisplayOnlyEditFormItems = true">To Edit</label>
+      <label class="btn btn-switch" [class.active]="!shouldDisplayOnlyEditFormItems" (click)="shouldDisplayOnlyEditFormItems = false">All</label>
     </div>
     <div *ngIf="headerItemTemplate">
       <ng-template [ngTemplateOutlet]="headerItemTemplate"></ng-template>
     </div>
     <div>
       <label class="item-count-label">
-          {{paginatedItems[0].index + 1}}-{{paginatedItems[paginatedItems.length - 1].index + 1}} of {{values.size}} {{path[path.length - 1]}}
+        {{paginatableItems.size}} {{path[path.length - 1]}}
       </label>
       <br>
-      <pagination [totalItems]="values.size" [ngModel]="currentPage" [maxSize]="navigator.maxVisiblePageCount" [itemsPerPage]="navigator.itemsPerPage"
+      <pagination [totalItems]="paginatableItems.size" [ngModel]="currentPage" [maxSize]="navigator.maxVisiblePageCount" [itemsPerPage]="navigator.itemsPerPage"
         class="pagination-sm pagination-top" [boundaryLinks]="true" [rotate]="false" [firstText]="'❮❮'" [previousText]="'❮'"
         [nextText]="'❯'" [lastText]="'❯❯'" (pageChanged)="onPageChange($event.page)"></pagination>
     </div>

--- a/src/complex-list-field/complex-list-field.component.scss
+++ b/src/complex-list-field/complex-list-field.component.scss
@@ -49,3 +49,7 @@
     text-align: right;
   }
 }
+
+label.btn {
+  color: white !important;
+}

--- a/src/complex-list-field/complex-list-field.component.ts
+++ b/src/complex-list-field/complex-list-field.component.ts
@@ -214,6 +214,10 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
     return this.schema.viewTemplateConfig !== undefined;
   }
 
+  get sortable(): boolean {
+    return this.schema.sortable && !this.shouldDisplayOnlyEditFormItems;
+  }
+
   set shouldDisplayOnlyEditFormItems(value: boolean) {
     this.currentPage = 1;
     this._shouldDisplayOnlyEditFormItems = value;

--- a/src/complex-list-field/complex-list-field.component.ts
+++ b/src/complex-list-field/complex-list-field.component.ts
@@ -30,7 +30,7 @@ import {
   ChangeDetectorRef,
   TemplateRef
 } from '@angular/core';
-import { List, Map, Set } from 'immutable';
+import { List, Map, Set, Iterable } from 'immutable';
 
 import { AbstractListFieldComponent } from '../abstract-list-field';
 import {
@@ -57,7 +57,8 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   @Input() schema: JSONSchema;
   @Input() path: Array<any>;
 
-  paginatedItems: Array<PaginatedItem>;
+  paginatedItems: Iterable<number, PaginatedItem>;
+  paginatableItems: Iterable<number, PaginatedItem>;
 
   foundIndices: Array<number>;
   currentFound = 0;
@@ -65,6 +66,7 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   findExpression: string;
   navigator: LongListNavigatorConfig;
   shouldDisplayFoundNavigation: boolean;
+  private _shouldDisplayOnlyEditFormItems = true;
 
   constructor(public appGlobalsService: AppGlobalsService,
     public errorsService: ErrorsService,
@@ -79,7 +81,8 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
   ngOnInit() {
     super.ngOnInit();
     this.navigator = this.schema.longListNavigatorConfig;
-    this.paginatedItems = this.getItemsForPage(this.currentPage);
+    this.paginatableItems = this.getPaginatableItems();
+    this.paginatedItems = this.getPaginatableItemsForPage(this.currentPage);
 
     if (this.navigator) {
       this.listPageChangerService
@@ -105,7 +108,8 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
             this.currentPage = lastPage;
           }
         }
-        this.paginatedItems = this.getItemsForPage(this.currentPage);
+        this.paginatableItems = this.getPaginatableItems();
+        this.paginatedItems = this.getPaginatableItemsForPage(this.currentPage);
       }
     }
   }
@@ -170,17 +174,32 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
 
   onPageChange(page: number) {
     this.currentPage = page;
-    this.paginatedItems = this.getItemsForPage(page);
+    this.paginatedItems = this.getPaginatableItemsForPage(page);
   }
 
-  getItemsForPage(page: number): Array<PaginatedItem> {
-    let indices = this.getIndicesToDisplay(page);
+  getPaginatableItemsForPage(page: number): Iterable<number, PaginatedItem> {
+    if (this.navigator) {
+      let begin = (page - 1) * this.navigator.itemsPerPage;
+      let end = (page * this.navigator.itemsPerPage);
+      return this.paginatableItems.slice(begin, end);
+    } else {
+      return this.paginatableItems;
+    }
+  }
 
-    return indices.map((index) => {
-      let showEditForm = this.schema.viewTemplateConfig ? this.schema.viewTemplateConfig.showEditForm : undefined;
-      let isEditFormVisible = !showEditForm || showEditForm(this.values.get(index));
-      return { index, isEditFormVisible };
-    });
+  getPaginatableItems(): Iterable<number, PaginatedItem> {
+    return this.values
+      .map((value, index) => {
+        let viewTemplateConfig = this.schema.viewTemplateConfig;
+        let isEditFormVisible = viewTemplateConfig ? viewTemplateConfig.showEditForm(value) : true;
+        return { index, isEditFormVisible };
+      }).filter(item => {
+        if (this.shouldDisplayOnlyEditFormItems) {
+          return item.isEditFormVisible;
+        } else {
+          return true;
+        }
+      });
   }
 
   getPageForIndex(index: number): number {
@@ -195,21 +214,14 @@ export class ComplexListFieldComponent extends AbstractListFieldComponent implem
     return this.schema.viewTemplateConfig !== undefined;
   }
 
-  private getIndicesToDisplay(page: number): Array<number> {
-    let indices: Array<number>;
-    if (this.navigator) {
-      let start = (page - 1) * this.navigator.itemsPerPage;
-      indices = Array.apply(0, Array(this.navigator.itemsPerPage))
-        .map((el, index) => start + index);
-      // check if the indices includes some numbers that are out of values index range.
-      let lastIndexDiff = indices[indices.length - 1] - (this.values.size - 1);
-      if (lastIndexDiff > 0) {
-        indices.splice(indices.length - lastIndexDiff);
-      }
-    } else {
-      indices = this.values.keySeq().toArray();
-    }
+  set shouldDisplayOnlyEditFormItems(value: boolean) {
+    this.currentPage = 1;
+    this._shouldDisplayOnlyEditFormItems = value;
+    this.paginatableItems = this.getPaginatableItems();
+    this.paginatedItems = this.getPaginatableItemsForPage(this.currentPage);
+  }
 
-    return indices;
+  get shouldDisplayOnlyEditFormItems(): boolean {
+    return this._shouldDisplayOnlyEditFormItems;
   }
 }

--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -315,7 +315,6 @@ body, html {
   }
 
   .btn {
-    border-radius: 0;
 
     &.btn-success {
       background-color: $green-sea;
@@ -374,6 +373,19 @@ body, html {
 
     button {
       pointer-events: none;
+    }
+  }
+  
+  $custom-active-color: #31617B;
+  .pagination > .active > a {
+    background-color: $custom-active-color;
+    border-color: $custom-active-color;
+  }
+  
+  .btn.btn-switch {
+    background-color: #7DA0B3;
+    &.active {
+      background-color: $custom-active-color;
     }
   }
 }

--- a/src/shared/interfaces/paginated-item.ts
+++ b/src/shared/interfaces/paginated-item.ts
@@ -1,4 +1,4 @@
 export interface PaginatedItem {
-  index?: number;
-  isEditFormVisible?: boolean;
+  index: number;
+  isEditFormVisible: boolean;
 }

--- a/src/shared/interfaces/view-template-config.ts
+++ b/src/shared/interfaces/view-template-config.ts
@@ -2,6 +2,8 @@ import { Map } from 'immutable';
 
 export interface ViewTemplateConfig {
     /**
+     * Template to be used represent list item if `showEditForm` returns false
+     *
      * Used for complex list fields only (list of nested objects).
      * The template needs to be defined with <ng-template #myTemplate></ng-template> and passed to the json-editor like so:
      * <json-editor [templates]="{myTemplate: myTemplate}"></json-editor>
@@ -15,5 +17,5 @@ export interface ViewTemplateConfig {
      * - true if the fields to edit should be visible by default
      * - false if the fields to edit should be hidden by default
      */
-    showEditForm?: (item: Map<string, any>) => boolean;
+    showEditForm: (item: Map<string, any>) => boolean;
   };


### PR DESCRIPTION
* Adds switch to see only complex-list items to edit.

* Changes .active class color for complex-list navigator.

## UI

![screen shot 2017-08-21 at 16 42 07](https://user-images.githubusercontent.com/4868667/29524277-ab6e3f52-868f-11e7-8e50-7b8a011308ad.png)