### PR TITLE
fix docs building issue (closes #357)

### DIFF
--- a/src/shared/services/remote-autocompletion.service.ts
+++ b/src/shared/services/remote-autocompletion.service.ts
@@ -23,6 +23,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
 
 import { AutocompletionResult, AutocompletionConfig } from '../interfaces';
 import { PathUtilService } from './path-util.service';


### PR DESCRIPTION
`typedoc` compiles the code when building the docs, and uses `tsc` not `ngc` that's why missing import was causing docs build to fail for docs but not library build.