### PR TITLE
change json$ to be Subject instead of ReplaySubject

### DIFF
--- a/src/shared/services/json-store.service.ts
+++ b/src/shared/services/json-store.service.ts
@@ -1,6 +1,29 @@
+/*
+ * This file is part of ng2-json-editor.
+ * Copyright (C) 2016 CERN.
+ *
+ * ng2-json-editor is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * ng2-json-editor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ng2-json-editor; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ * In applying this license, CERN does not
+ * waive the privileges and immunities granted to it by virtue of its status
+ * as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
 import { Injectable } from '@angular/core';
 import { Map, List, fromJS } from 'immutable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Subject } from 'rxjs/Subject';
 
 import { PathUtilService } from './path-util.service';
 import { KeysStoreService } from './keys-store.service';
@@ -11,7 +34,7 @@ import { SizedStack } from '../classes';
 export class JsonStoreService {
 
   readonly patchesByPath$ = new ReplaySubject<JsonPatchesByPath>(1);
-  readonly json$ = new ReplaySubject<Map<string, any>>(1);
+  readonly json$ = new Subject<Map<string, any>>();
 
   private patchesByPath: JsonPatchesByPath = {};
   private json: Map<string, any>;
@@ -23,7 +46,6 @@ export class JsonStoreService {
     private keysStoreService: KeysStoreService) { }
 
   setIn(path: Array<any>, value: any, allowUndo = true) {
-    // if value is undefined or empty string
     if (value === '' || value === undefined) {
       this.removeIn(path);
       return;


### PR DESCRIPTION
* Fixes the bug when setJson called the second time with a different
value but subscribe is returning a previous value due to
ReplaySubject(1).

* Adds license header