### PR TITLE
make the sidebar collapsible

### DIFF
--- a/src/add-field-dropdown/add-field-dropdown.component.html
+++ b/src/add-field-dropdown/add-field-dropdown.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="!hidden" class="btn-group add-field-dropdown-container" dropdown keyboardNav="true" [isDisabled]="isDisabled" (onShown)="onDropdownShown()">
   <button type="button" class="btn btn-add-field-dropdown" dropdownToggle>
-    <ng-content></ng-content> <i class="fa fa-caret-down"></i>
+     <ng-content></ng-content> 
   </button>
   <ul class="dropdown-menu" *dropdownMenu>
     <li class="dropdown-filter-container">

--- a/src/add-field-dropdown/add-field-dropdown.component.scss
+++ b/src/add-field-dropdown/add-field-dropdown.component.scss
@@ -19,7 +19,6 @@
 
 .dropdown-filter-container {
   padding: 0 3px;
-  
   input {
     width: 100%;
   }

--- a/src/bottom-console-badges/bottom-console-badges.component.html
+++ b/src/bottom-console-badges/bottom-console-badges.component.html
@@ -1,11 +1,17 @@
 <div class="badges-container">
-  <a *ngIf="errorCount > 0" class="error" (click)="onBadgeClick($event, 'Errors')">
-        <span class="">Errors</span> <span class="badge">{{errorCount}}</span>
-    </a>
-  <a *ngIf="warningCount > 0" class="warning" (click)="onBadgeClick($event, 'Warnings')">
-        <span>Warnings</span> <span class="badge">{{warningCount}}</span>
+  <a *ngIf="errorCount > 0" class="error" (click)="onBadgeClick($event, 'Errors')" tooltip="{{errorCount}} error(s)" placement="right">
+    <span class="error fa-stack fa-lg">
+      <i class="fa fa-times fa-stack-1x fa-inverse"></i>
+    </span>
   </a>
-  <a *ngIf="patchCount > 0" class="patch" (click)="onBadgeClick($event, 'Patches')">
-    <span>Conflicts</span> <span class="badge">{{patchCount}}</span>
+  <a *ngIf="warningCount > 0" class="warning" (click)="onBadgeClick($event, 'Warnings')" tooltip="{{warningCount}} warning(s)" placement="right">
+    <span class="warning fa-stack fa-lg"> 
+      <i class="fa fa-exclamation fa-stack-1x fa-inverse"></i>
+    </span>
+  </a>
+  <a *ngIf="patchCount > 0" class="patch" (click)="onBadgeClick($event, 'Patches')" tooltip="{{patchCount}} conflicts(s)" placement="right">
+    <span class="patch fa-stack fa-lg">
+      <i class="fa fa-bolt fa-stack-1x fa-inverse"></i>
+    </span>
   </a>
 </div>

--- a/src/bottom-console-badges/bottom-console-badges.component.scss
+++ b/src/bottom-console-badges/bottom-console-badges.component.scss
@@ -1,68 +1,63 @@
-$error-color: #D14024;
-$light-error-color: lighten($error-color, 10%);
-$warning-color: #f1c40f;
-$light-warning-color: lighten($warning-color, 10%);
-$patch-color: #e67e22;
-$light-patch-color: lighten($patch-color, 10%);
-
+$error-color: #d14024;
+$warning-color: #fbd503;
+$patch-color: #f96509;
 
 .error {
-  color: $error-color;
-  .badge {
-    background-color: $error-color;
-
-    &:hover {
-      background-color: $light-error-color
+  span {
+    border: 2px solid $error-color;  
+    i {
+      color: $error-color;
+      padding-bottom: 2px;
     }
-  }
-
-  &:hover {
-    color: $light-error-color
   }
 }
 
 .warning {
-  color: $warning-color;
-  .badge {
-    background-color: $warning-color;
-
-    &:hover {
-      background-color: $light-warning-color
+  span {
+    border: 2px solid $warning-color;
+    i {
+      color: $warning-color;
     }
-  }
-
-  &:hover {
-    color: $light-warning-color
   }
 }
 
 .patch {
-  color: $patch-color;
-  .badge {
-    background-color: $patch-color;
-
-    &:hover {
-      background-color: $light-patch-color
+  span {
+    border: 2px solid $patch-color;
+    i {
+      color: $patch-color;
     }
-  }
-
-  &:hover {
-    color: $light-patch-color
   }
 }
 
 a {
   text-decoration: none;
-  &:hover {
-    cursor: pointer;
-  }
-  padding-right: 7px;
+  cursor: pointer;
   padding-top: 7px;
+  i {
+    transition: all 0.35s ease-in-out;
+    &:hover {
+      font-size: 1.10em;
+    } 
+  }
 }
 
 .badges-container {
   display: flex;
-
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  a {
+    display: flex;
+    width: 80%;
+    margin-top: 5px;
+    span {
+      display: flex;
+      align-items: center;
+      height: 30px;
+      border-radius: 20%;
+    }
+  }
 }
 
 @media screen and (max-width: 1440px) {

--- a/src/json-editor.component.html
+++ b/src/json-editor.component.html
@@ -1,17 +1,30 @@
-<div id="ng2-json-editor" class="row editor-container" [ngClass]="shorterEditorContainerClass">
-  <div *ngIf="!config.compact" class="col-md-2 menu-container">
+<div id="ng2-json-editor" class="editor-container" [ngClass]="shorterEditorContainerClass">
+  
+  <div  *ngIf="!config.compact" class="collapsed-menu-container">
+    <add-field-dropdown [fields]="keys$ | async" [pathString]="pathString" 
+    [schema]="fixedSchema" class="add-field-button">
+      <i class="fa fa-plus fa-lg" aria-hidden="true" tooltip="Add Field" placement="right"></i>
+    </add-field-dropdown>
+    <bottom-console-badges (badgeClick)="openBottomConsole($event)"></bottom-console-badges>
+    <span class="open-sidebar-container" (click)="isSidebarCollapsed = !isSidebarCollapsed">
+      <i class="fa fa-angle-right fa-4x" [ngClass]="!isSidebarCollapsed ? 'rotate' : ''"></i>
+    </span>
+  </div>
+
+  <div *ngIf="!config.compact" class="menu-container" [ngClass]="isSidebarCollapsed ? 'close' : 'open'">
     <tree-menu [record]="_record" [schema]="fixedSchema"></tree-menu>
-    <add-field-dropdown [fields]="keys$ | async" [pathString]="pathString" [schema]="fixedSchema">Add field</add-field-dropdown>
     <hr>
     <div *ngIf="config.enableAdminModeSwitch" class="admin-mode" tooltip="Allows editing all fields (use with care)">
       <input id="admin-mode-checkbox" type="checkbox" [(ngModel)]="appGlobalsService.adminMode" />
       <label class="admin-mode" for="admin-mode-checkbox">Enable Admin Mode</label>
     </div>
     <hr>
-    <bottom-console-badges (badgeClick)="openBottomConsole($event)"></bottom-console-badges>
   </div>
-  <div id="middle-main-container" class="middle main-container" [class.compact]="config.compact" [ngClass]="middleContainerColMdClass" [shortcuts]="customShortcutKeys">
-    <add-field-dropdown *ngIf="config.compact" [fields]="keys$ | async" [pathString]="pathString" [schema]="fixedSchema">Add field</add-field-dropdown>    
+
+  <div id="middle-main-container" class="middle main-container" [class.compact]="config.compact" [shortcuts]="customShortcutKeys"
+    [ngClass]="isPreviewerHidden ? 'maximizeEditor' : 'maximizeEditor'">
+    <add-field-dropdown *ngIf="config.compact" [fields]="keys$ | async" [pathString]="pathString" 
+    [schema]="fixedSchema">Add field</add-field-dropdown>
     <tabset *ngIf="config.tabsConfig">
       <tab *ngFor="let tabName of tabNames; trackBy:trackByElement" [heading]="tabName" (select)="activeTabName = tabName" [active]="isActiveTab(tabName)">
         <sub-record [value]="_record" [tabName]="tabName" [schema]="fixedSchema" [keys]="keys$ | async" [pathString]="pathString"></sub-record>
@@ -19,10 +32,12 @@
     </tabset>
     <sub-record *ngIf="!config.tabsConfig" [value]="_record" [schema]="fixedSchema" [keys]="keys$ | async" [pathString]="pathString"></sub-record>
   </div>
-  <div id="right-main-container" *ngIf="!isPreviewerDisabled" [ngClass]="rightContainerColMdClass" class="main-container">
+
+  <div id="right-main-container" *ngIf="!isPreviewerDisabled" class="main-container right" [ngClass]="isPreviewerHidden ? 'minimizePreview' : 'maximizePreview' ">
     <button id="btn-preview-toggle" type="button" class="btn btn-default btn-toggle" (click)="isPreviewerHidden = !isPreviewerHidden">{{isPreviewerHidden ? "Show Preview" : "Hide Preview"}}</button>
     <editor-previewer [hidden]="isPreviewerHidden" [previews]="previews"> </editor-previewer>
   </div>
+
 </div>
 
 <bottom-console *ngIf="!config.compact" [activeTab]="bottomConsoleActiveTab" [isOpen]="isBottomConsoleOpen" (onCollapse)="isBottomConsoleOpen = $event"></bottom-console>

--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -30,9 +30,15 @@ $error-color: $alizarin;
 $label-holder-background-color: #dae8ef;
 $label-holder-button-color: #595959;
 
+//widths for different panels
+$default-sidebar-width: 3.5%;
+$expanded-sidebar-width: 320px;
+$default-preview-width: 50%;
+$default-middle-container-width: 40.5%;
+
 @mixin top-level-add-field-dropdown-container {
   div.dropdown {
-    width: 100%;
+    width: 100vh;
   }
 
   ul.dropdown-menu {
@@ -78,18 +84,26 @@ $label-holder-button-color: #595959;
 
 html, body {
   height:100%;
+  overflow-y: hidden;
+  background-color: #ecf0f1;
 }
 
 .editor-container {
+  display: flex;
+  flex-direction: row;
   height: 100%;
+  width: 100%;
   margin-right: 0px;
   margin-left: 0px;
   .row {
     margin-left: 0px;
     margin-right: 0px;
   }
-
 }
+
+.bs-tooltip-right {
+  width: 120px !important;
+}    
 
 .shorter-editor-container {
   height: 75%;
@@ -177,16 +191,109 @@ html, body {
   .add-field-dropdown-container {
     width: 100%;
   }
-
+  
   .middle.main-container {
     padding: 0px;
   }
 
   .menu-container {
-    background-color: #1D2D3D;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background-color: #2c3e50;
     height: 100%;
-    overflow: auto;
+    width: 0%;
+    overflow-x: hidden;
+    opacity: 0;
+    visibility: hidden;
     @include top-level-add-field-dropdown-container;
+    transition: width 0.1s ease-in;
+    &.open {
+      opacity: 1;
+      visibility: visible;
+      width: $expanded-sidebar-width;
+      padding-left: 5px;
+    }
+  }
+
+  .collapsed-menu-container {
+    position: relative;
+    background-color: #1D2D3D;
+    width: $default-sidebar-width;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    
+    .add-field-button {
+      position: absolute;
+      top: 0px;
+      margin-top: 10px;
+      display: flex;
+      justify-content: center;
+      width: 100%;
+      cursor: pointer;
+      .btn-add-field-dropdown {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        opacity: 1;
+        background-color: transparent;
+        &:hover, &:focus, &:active {
+          outline: none;
+        }
+        i {
+          color: #ddd;
+          &:hover {
+            color: white;
+          }
+        }
+      }
+    }
+
+    .open-sidebar-container {
+      cursor: pointer;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      margin-top: 20px;
+      border-top: 2px solid #283948;
+      border-right: 2px solid #283948;
+      color: #ddd;
+      &:hover {
+        color: white;
+        text-shadow: 3px 3px 14px #2a5d88;
+      }
+      .fa-angle-right {
+        transition: all 0.5s ease-in-out;
+        -webkit-transition: all 0.5s ease-in-out;
+        -ms-transition: all 0.5s ease-in-out;
+        &.rotate {
+          transform: rotate(-180deg);
+          -webkit-transform: rotate(-180deg);
+          -ms-transform: rotate(-180deg);
+        }
+      }
+    }
+  }
+
+  .middle.main-container {
+    width: $default-middle-container-width;
+    &.maximizeEditor {
+      width: 97%;
+    }
+  }
+
+  .right.main-container {
+    width: $default-preview-width;
+    &.minimizePreview {
+      width: 0%;
+    }
+    .btn-toggle {
+      position: fixed;
+      right: 0;
+    }
   }
 
   .editor-btn-delete {
@@ -406,6 +513,12 @@ html, body {
     &.active {
       background-color: $custom-active-color;
     }
+  }
+  @media all and (max-width: 800px) {
+    .collapsed-menu-container { flex: 1 0px; }
+    .menu-container.open {flex: 3}
+    .middle.main-container { flex: 9; }
+    .right.main-container { flex: 5; }
   }
 }
 

--- a/src/json-editor.component.ts
+++ b/src/json-editor.component.ts
@@ -91,6 +91,7 @@ export class JsonEditorComponent extends AbstractSubscriberComponent implements 
   previews: Array<Preview>;
   isPreviewerHidden: boolean;
   isBottomConsoleOpen = false;
+  isSidebarCollapsed = true;
   bottomConsoleActiveTab = '';
   customShortcutKeys: CustomShortcutKeys;
   // altered schema enchanced with configs
@@ -253,20 +254,6 @@ export class JsonEditorComponent extends AbstractSubscriberComponent implements 
 
   get isPreviewerDisabled(): boolean {
     return this.config.previews === undefined || this.config.previews.length === 0;
-  }
-
-  get rightContainerColMdClass(): string {
-    return this.isPreviewerHidden ? 'col-md-1' : 'col-md-4';
-  }
-
-  get middleContainerColMdClass(): string {
-    if (this.config.compact) {
-      return 'col-md-12';
-    }
-    if (this.isPreviewerDisabled) {
-      return 'col-md-10';
-    }
-    return this.isPreviewerHidden ? 'col-md-9' : 'col-md-6';
   }
 
   set activeTabName(tabName: string) {

--- a/src/object-field/object-field.component.html
+++ b/src/object-field/object-field.component.html
@@ -40,7 +40,7 @@
   <tr>
     <td class="button-holder">
       <add-field-dropdown [fields]="keys$ | async" [pathString]="pathString" [schema]="schema" [isDisabled]="disabled">
-        <i class="fa fa-plus"></i>
+        <i class="fa fa-plus"></i> <i class="fa fa-caret-down"></i>
       </add-field-dropdown>
     </td>
   </tr>

--- a/src/table-list-field/table-list-field.component.html
+++ b/src/table-list-field/table-list-field.component.html
@@ -7,7 +7,7 @@
         </th>
         <th class="button-holder" [class.sortable]="schema.sortable">
           <add-field-dropdown *ngIf="values.size > 0" [fields]="keys$ | async" [pathString]="pathString" [schema]="schema.items" [isDisabled]="disabled">
-            <i class="fa fa-plus"></i>
+            <i class="fa fa-plus"></i> <i class="fa fa-caret-down"></i>
           </add-field-dropdown>
         </th>
       </tr>

--- a/src/tree-menu/tree-menu.component.scss
+++ b/src/tree-menu/tree-menu.component.scss
@@ -1,6 +1,5 @@
 div.tree-menu-container {
-  padding: 8px 0;
-  overflow-x: hidden;
+  padding: 8px 2px 0 0;
   overflow-y: auto;
   text-align: center;
 }
@@ -9,7 +8,7 @@ ul.menu-item-container {
 	list-style: none;
   text-align: left;
   padding-top: 8px;
-
+  padding-left: 0px;
   li {
     margin-bottom: 2px;
   }


### PR DESCRIPTION
The sidebar collapses to a narrower bar, like so:
![screenshot from 2018-02-12 11-20-18](https://user-images.githubusercontent.com/11242410/36092434-a1f0113a-0fe7-11e8-945e-3ed3dc4c679b.png)


On a smaller screen (iPad):
![screenshot from 2018-02-12 11-27-37](https://user-images.githubusercontent.com/11242410/36092475-c810032a-0fe7-11e8-9450-ef7671874308.png)

![screenshot from 2018-02-12 11-28-30](https://user-images.githubusercontent.com/11242410/36092504-e468bd82-0fe7-11e8-9490-0857040e39ec.png)

When the sidebar is expanded:
![screenshot from 2018-02-12 11-29-17](https://user-images.githubusercontent.com/11242410/36092541-fe13b12e-0fe7-11e8-96fb-b3aa33a96d93.png)
