### PR TITLE
change contenteditable el from div to span

### DIFF
--- a/e2e/shortcut-action/shortcut-action.e2e-spec.ts
+++ b/e2e/shortcut-action/shortcut-action.e2e-spec.ts
@@ -40,7 +40,7 @@ describe('ShortcutAction', function () {
   it(`should add a new row under table using 'alt+a' shortcut`, () => {
     page.getNumberOfChildRowsbyId('/keywords')
       .then(tableRowsNum => {
-        const inputElem = page.getChildOfElementByCss(page.getElementById('/keywords/0'), 'div[contenteditable=true]');
+        const inputElem = page.getChildOfElementByCss(page.getElementById('/keywords/0'), 'span[contenteditable=true]');
         inputElem.sendKeys(protractor.Key.chord(protractor.Key.ALT, 'a'));
         const newTableRowsNumPromise = page.getNumberOfChildRowsbyId('/keywords');
         expect(newTableRowsNumPromise).toEqual(tableRowsNum + 1);
@@ -50,7 +50,7 @@ describe('ShortcutAction', function () {
   it(`should add a new row under table using 'mod+shift+a' shortcut`, () => {
     page.getNumberOfChildRowsbyId('/arxiv_eprints')
       .then(tableRowsNum => {
-        const inputElem = page.getChildOfElementByCss(page.getElementById('/arxiv_eprints/0/value'), 'div[contenteditable=true]');
+        const inputElem = page.getChildOfElementByCss(page.getElementById('/arxiv_eprints/0/value'), 'span[contenteditable=true]');
         inputElem.sendKeys(protractor.Key.chord(mod, protractor.Key.SHIFT, 'a'));
         const newTableRowsNumPromise = page.getNumberOfChildRowsbyId('/arxiv_eprints');
         expect(newTableRowsNumPromise).toEqual(tableRowsNum + 1);
@@ -59,7 +59,7 @@ describe('ShortcutAction', function () {
 
   it(`should add a new row under table using 'mod+shift+b' shortcut`, () => {
     const currentRowPromise = page.getValuesOfChildrenById('/keywords/1');
-    const inputElem = page.getChildOfElementByCss(page.getElementById('/keywords/0/value'), 'div[contenteditable=true]');
+    const inputElem = page.getChildOfElementByCss(page.getElementById('/keywords/0/value'), 'span[contenteditable=true]');
     inputElem.sendKeys(protractor.Key.chord(mod, protractor.Key.SHIFT, 'b'));
     currentRowPromise
       .then(currentRow => {
@@ -72,7 +72,7 @@ describe('ShortcutAction', function () {
     const currentFirstRowPromise = page.getValuesOfChildrenById('/external_system_identifiers/0');
     const currentSecondRowPromise = page.getValuesOfChildrenById('/external_system_identifiers/1');
     const currentElem = page
-      .getChildOfElementByCss(page.getElementById('/external_system_identifiers/1/value'), 'div[contenteditable=true]');
+      .getChildOfElementByCss(page.getElementById('/external_system_identifiers/1/value'), 'span[contenteditable=true]');
     currentElem.sendKeys(protractor.Key.chord(mod, protractor.Key.SHIFT, protractor.Key.UP));
     const targetFirstRowPromise = page.getValuesOfChildrenById('/external_system_identifiers/0');
     const targetSecondRowPromise = page.getValuesOfChildrenById('/external_system_identifiers/1');
@@ -85,9 +85,9 @@ describe('ShortcutAction', function () {
 
   it(`should move row down using 'mod+shift+down' shortcut`, () => {
     const currentRowPromise = page.getValuesOfChildrenById('/external_system_identifiers/0');
-    let currentElem = page.getChildOfElementByCss(page.getElementById('/external_system_identifiers/0/value'), 'div[contenteditable=true]');
+    let currentElem = page.getChildOfElementByCss(page.getElementById('/external_system_identifiers/0/value'), 'span[contenteditable=true]');
     currentElem.sendKeys(protractor.Key.chord(mod, protractor.Key.SHIFT, protractor.Key.DOWN));
-    currentElem = page.getChildOfElementByCss(page.getElementById('/external_system_identifiers/1/value'), 'div[contenteditable=true]');
+    currentElem = page.getChildOfElementByCss(page.getElementById('/external_system_identifiers/1/value'), 'span[contenteditable=true]');
     // Trigger move down shortcut two time in a row to test issue of not updating tabindexes correctly on sequential
     // trigger of the shortcut. As a result the shortcut was not working properly.
     currentElem.sendKeys(protractor.Key.chord(mod, protractor.Key.SHIFT, protractor.Key.DOWN));
@@ -96,14 +96,14 @@ describe('ShortcutAction', function () {
   });
 
   it(`should delete the current row in table  using 'mod+backspace' shortcut`, () => {
-    const elem = page.getChildOfElementByCss(page.getElementById('/keywords/0/value'), 'div[contenteditable=true]');
+    const elem = page.getChildOfElementByCss(page.getElementById('/keywords/0/value'), 'span[contenteditable=true]');
     const elemBeforeDeletionThatWillBeShifted = page
-      .getChildOfElementByCss(page.getElementById('/keywords/1/value'), 'div[contenteditable=true]')
+      .getChildOfElementByCss(page.getElementById('/keywords/1/value'), 'span[contenteditable=true]')
       .getText();
     const elemValuePromise = elem.getText();
     elem.sendKeys(protractor.Key.chord(mod, protractor.Key.BACK_SPACE));
     const elemAfterDeletionAndThatWasShifted = page
-      .getChildOfElementByCss(page.getElementById('/keywords/0/value'), 'div[contenteditable=true]');
+      .getChildOfElementByCss(page.getElementById('/keywords/0/value'), 'span[contenteditable=true]');
     expect(elemAfterDeletionAndThatWasShifted.getText()).not.toEqual(elemValuePromise);
     expect(elemAfterDeletionAndThatWasShifted.getText()).toEqual(elemBeforeDeletionThatWillBeShifted);
   });
@@ -111,7 +111,7 @@ describe('ShortcutAction', function () {
   it(`should copy new row under abstracts.0 table using 'alt+c' shortcut.
     The copied cell under the focused one must be empty and the remaining cells must be exactly copied.`, () => {
       const currentRowPromise = page.getValuesOfChildrenById('/imprints/0');
-      const inputElem = page.getChildOfElementByCss(page.getElementById('/imprints/0/date'), 'div[contenteditable=true]');
+      const inputElem = page.getChildOfElementByCss(page.getElementById('/imprints/0/date'), 'span[contenteditable=true]');
       inputElem.sendKeys(protractor.Key.chord(protractor.Key.ALT, 'c'));
       const targetRowPromise = page.getValuesOfChildrenById('/imprints/1');
       protractor.promise.all([currentRowPromise, targetRowPromise])
@@ -125,11 +125,11 @@ describe('ShortcutAction', function () {
 
   it(`should copy new row under references table using 'mod+alt+r' shortcut.
     It must copy the exact value of the root element eg Copy the whole element under the focused one.`, () => {
-      const inputElem = page.getChildOfElementByCss(page.getElementById('/imprints/0/date'), 'div[contenteditable=true]');
+      const inputElem = page.getChildOfElementByCss(page.getElementById('/imprints/0/date'), 'span[contenteditable=true]');
       const numberOfContentEditableElementsBeforeCopyPromise = page.getNumberOfContentEditableElementsById('/imprints/0');
       const numberOfInputElementsBeforeCopyPromise = page.getNumberOfInputElementsById('/imprints/0');
       inputElem.sendKeys(protractor.Key.chord(mod, protractor.Key.ALT, 'r'));
-      const afterCopyInputElemValue = page.getChildOfElementByCss(page.getElementById('/imprints/1/date'), 'div[contenteditable=true]')
+      const afterCopyInputElemValue = page.getChildOfElementByCss(page.getElementById('/imprints/1/date'), 'span[contenteditable=true]')
         .getText();
       expect(inputElem.getText()).toEqual(afterCopyInputElemValue);
       const numberOfContentEditableElementsAfterCopyPromise = page.getNumberOfContentEditableElementsById('/imprints/1');

--- a/e2e/shortcut-action/shortcut-action.po.ts
+++ b/e2e/shortcut-action/shortcut-action.po.ts
@@ -46,7 +46,7 @@ export class ShortcutActionPage extends Ng2JsonEditorPage {
 
   getNumberOfContentEditableElementsById(id: string): WDPromise<number> {
     const elem = element(by.id(id));
-    return elem.all(by.css('div[contenteditable=true]')).count();
+    return elem.all(by.css('span[contenteditable=true]')).count();
   }
 
   getNumberOfInputElementsById(id: string): WDPromise<number> {
@@ -55,7 +55,7 @@ export class ShortcutActionPage extends Ng2JsonEditorPage {
   }
 
   getValuesOfChildrenById(id: string): WDPromise<Array<string>> {
-    const elems = this.getChildrenOfElementByCss(this.getElementById(id), 'div[contenteditable=true], input');
+    const elems = this.getChildrenOfElementByCss(this.getElementById(id), 'span[contenteditable=true], input');
     return elems
       .map(elem => {
         return elem.getTagName()

--- a/src/primitive-field/primitive-field.component.scss
+++ b/src/primitive-field/primitive-field.component.scss
@@ -1,4 +1,4 @@
-td.value-container div[contenteditable=true],
+td.value-container span[contenteditable=true],
 td.value-container input {
   vertical-align: middle;
   transition: all 0.5s ease;

--- a/src/primitive-field/primitive-field.component.spec.ts
+++ b/src/primitive-field/primitive-field.component.spec.ts
@@ -65,7 +65,7 @@ import { ContentModelDirective } from '../shared/directives';
  *
  * TODO: create a test helper class for this kind of functions!
  *
- * @param {HTMLElement} el - <div contenteditable=true> or <input> html element
+ * @param {HTMLElement} el - <span contenteditable=true> or <input> html element
  * @param {string} value - new value to be set to el.value
  */
 function changeInputElementValue(el: HTMLInputElement, value: string) {

--- a/src/shared/services/dom-util.service.ts
+++ b/src/shared/services/dom-util.service.ts
@@ -30,7 +30,7 @@ import { JsonPatch } from '../interfaces';
 @Injectable()
 export class DomUtilService {
 
-  private readonly editableSelector = '.value-container input, div[contenteditable=true], .switch-input, searchable-dropdown span.value';
+  private readonly editableSelector = '.value-container input, span[contenteditable=true], .switch-input, searchable-dropdown span.value';
   // highlight class is defined in json-editor.component.scss
   private readonly highlightClass = 'highlight';
   private highlightedElement: HTMLElement;
@@ -88,7 +88,7 @@ export class DomUtilService {
       }
       let nextSibling = direction > 0 ? elementParentCell.nextElementSibling : elementParentCell.previousElementSibling;
       while (nextSibling && nextSibling.nodeName === 'TD') {
-        const inputElement = nextSibling.querySelector(`input[tabindex='1'], div[contenteditable=true][tabindex='1']`) as HTMLElement;
+        const inputElement = nextSibling.querySelector(`input[tabindex='1'], span[contenteditable=true][tabindex='1']`) as HTMLElement;
         if (inputElement) {
           inputElement.focus();
           this.selectAllContent(inputElement);

--- a/src/string-input/string-input.component.html
+++ b/src/string-input/string-input.component.html
@@ -1,5 +1,5 @@
-<div [class.hidden]="latexPreviewShown" [attr.contenteditable]="!disabled" [attr.data-path]="pathString" [tabindex]="tabIndex"
+<span [class.hidden]="latexPreviewShown" [attr.contenteditable]="!disabled" [attr.data-path]="pathString" [tabindex]="tabIndex"
   [contentModel]="contentModel" (contentModelChange)="contentModelChange($event)" (blur)="onBlur()" (keypress)="onKeypress.emit($event)"
-  attr.placeholder="{{placeholder || '⁣\u2063'}}" #contentEditable></div>
+  attr.placeholder="{{placeholder || '⁣\u2063'}}" #contentEditable></span>
 <div [class.hidden]="!latexPreviewEnabled || !latexPreviewShown" (click)="hideLatexPreview(contentEditable)" (blur)="hideLatexPreview(contentEditable)"
   #latexPreview></div>

--- a/src/string-input/string-input.component.ts
+++ b/src/string-input/string-input.component.ts
@@ -60,7 +60,7 @@ export class StringInputComponent implements AfterViewInit, OnInit, OnChanges {
   @Output() valueChange = new EventEmitter<string>();
 
   latexPreviewShown: boolean;
-  // updated as typed in contenteditable div, doesn't trigger latex re-rendering.
+  // updated as typed in contenteditable el, doesn't trigger latex re-rendering.
   contentModel: string;
 
   constructor(public domUtilService: DomUtilService, public katexService: KatexService) { }
@@ -100,9 +100,9 @@ export class StringInputComponent implements AfterViewInit, OnInit, OnChanges {
     this.katexService.renderMathInText(this.value, this.latexPreviewEl.nativeElement);
   }
 
-  hideLatexPreview(contentEditableDiv: HTMLElement) {
+  hideLatexPreview(contentEditableEl: HTMLElement) {
     this.latexPreviewShown = false;
-    setTimeout(() => contentEditableDiv.focus());
+    setTimeout(() => contentEditableEl.focus());
   }
 
   contentModelChange(value: string) {


### PR DESCRIPTION
* This fixes the issue with Firefox which inserts unnecesary <br>'s to
div[contenteditable]. Those <br>'s become the part of the actual value
in the edited json and creates problems with validation etc.