### PR TITLE
fix auto-complete field selection by clicking bug

### DIFF
--- a/src/autocomplete-input/autocomplete-input.component.html
+++ b/src/autocomplete-input/autocomplete-input.component.html
@@ -1,6 +1,18 @@
+<ng-template let-match="match" #matchWrapper>
+  <div style="width: 100%; height: 100%; padding: 3px 20px;" (mousedown)="onMatchWrapperMouseDown(match)">
+    <ng-template [ngTemplateOutlet]="customItemTemplate || defaultItemTemplate"
+      [ngTemplateOutletContext]="{item:match.item, index:i, match:match, query:query}"></ng-template>
+  </div>
+</ng-template>
+
+<ng-template #defaultItemTemplate let-match="match">
+  {{match.value}}
+</ng-template>
+
 <div class="autocomplete-container">
-  <input attr.data-path="{{pathString}}" [ngModel]="value" (ngModelChange)="onModelChange($event)" (keypress)="onKeypress.emit($event)"
-    (blur)="onBlur.emit()" [typeahead]="dataSource" [typeaheadOptionsLimit]="autocompletionConfig.size" [typeaheadOptionField]="typeaheadOptionField"
-    [typeaheadItemTemplate]="customItemTemplate" (typeaheadOnSelect)="onMatchSelect($event)" [typeaheadWaitMs]="200" [tabindex]="tabIndex"
-    placeholder="{{placeholder}}">
+  <input attr.data-path="{{pathString}}" [ngModel]="value" (ngModelChange)="onModelChange($event)"
+    (keypress)="onKeypress.emit($event)" (blur)="onBlur.emit()" [typeahead]="dataSource"
+    [typeaheadOptionsLimit]="autocompletionConfig.size" [typeaheadOptionField]="typeaheadOptionField"
+    [typeaheadItemTemplate]="matchWrapper" (typeaheadOnSelect)="onMatchSelect($event)" [typeaheadWaitMs]="200"
+    [tabindex]="tabIndex" placeholder="{{placeholder}}">
 </div>

--- a/src/autocomplete-input/autocomplete-input.component.ts
+++ b/src/autocomplete-input/autocomplete-input.component.ts
@@ -89,4 +89,9 @@ export class AutocompleteInputComponent implements OnInit {
   onMatchSelect(match: TypeaheadMatch) {
     this.onCompletionSelect.emit(match.item);
   }
+
+  onMatchWrapperMouseDown(match: TypeaheadMatch) {
+    this.onModelChange(match.value);
+    this.onMatchSelect(match);
+  }
 }

--- a/src/json-editor.component.scss
+++ b/src/json-editor.component.scss
@@ -573,3 +573,7 @@ complex-list-field {
     background: white;
     z-index: 1;
 }
+
+typeahead-container a[href='#'] {
+  padding: 0 !important;
+}


### PR DESCRIPTION
For some reason underlying ngx-bootstrap's typeahead wasn't working
consistently for selecting a completion by mouse click.

This is simplest and fastest solution without touching the
ngx-bootstrap's code.

NOTE: upgrading ngx-bootstrap wasn't an option since we
have to run angular 4 and and ngx-bootstrap 2.